### PR TITLE
Address raster fix review comments

### DIFF
--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1421,15 +1421,15 @@ def main() -> None:
         )
         combined_header = "combined pop"
         section_mask_ids.add(combined_header)
-        pop_results[aoi_key] = combined_task
+        pop_results[aoi_key][combined_header] = combined_task
 
     task_graph.join()
     rows = []
     for aoi_key, results in pop_results.items():
         row = {"aoi": aoi_key}
-        pop_count_results = results.get()
-        for header in pop_count_results:
-            row[header] = pop_count_results[header]
+        pop_count_results = results[combined_header].get()
+        for header in section_mask_ids:
+            row[header] = pop_count_results.get(header, "n/a")
         rows.append(row)
 
     df = pd.DataFrame(rows, columns=["aoi"] + list(section_mask_ids))

--- a/wwf_priority_places.yaml
+++ b/wwf_priority_places.yaml
@@ -8,6 +8,12 @@ focal_vectors:
     buffer_distance_m: 5000
     max_proposed_priority_area_ha: 1000000
 
+  - id: southernAfrica
+    path: data/priorityPlaces/southernAfrica
+    is_marine: false
+    max_proposed_priority_area_ha: 1000000
+    buffer_distance_m: 500000
+
   - id: amazon
     path: data/priorityPlaces/amazon
     is_marine: false


### PR DESCRIPTION
## Summary
- Preserve the `combined_header` entry in `pop_results` while still reading the combined task's per-mask population results.
- Use `section_mask_ids` when writing CSV rows so expected columns are retained even when a mask has no result for an AOI.
- Restore the `southernAfrica` priority-place entry that was removed in #25.

Related to #24 and follow-up to #25.

## Testing
- `python -m py_compile workflow_runner.py potential_beneficiaries_target.py utils/chunk_file.py`
- `git diff --check upstream/main...HEAD`