### PR TITLE
Add full raster extent analysis mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,8 @@ The analysis is orchestrated by a workflow runner that takes a YAML configuratio
        python workflow_runner.py example_roadmap2030_pop_downstream_analysis.yaml
 
 Use different YAML configuration files to run other analyses as needed.
+
+To run over the full overlapping raster extent instead of AOI vector files, set
+`inputs.analyze_full_raster_extent: true` and leave `aoi_vector_pattern` empty.
+The workflow will generate one AOI named `full_raster_extent` from the shared
+bounds of the population, travel-time, DEM, and condition rasters.

--- a/configs/example_roadmap2030_pop_downstream_analysis.yaml
+++ b/configs/example_roadmap2030_pop_downstream_analysis.yaml
@@ -11,6 +11,10 @@ inputs:
   traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
   dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
   subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  # Set this to true only when you intentionally want one generated AOI over
+  # the shared extent of the population, travel-time, DEM, and condition rasters.
+  # When true, leave aoi_vector_pattern empty.
+  analyze_full_raster_extent: false
   aoi_vector_pattern:
     - "./data/aois/aoi_by_country/*.gpkg"
     - "./data/aois/WWF-Int_Pilot-sites/*/*.shp"

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -214,15 +214,6 @@ def _as_list(x: Any) -> List[Any]:
     return [x]
 
 
-def _optional_bool(value: Any, key: str) -> bool:
-    """Parse an optional YAML boolean and reject ambiguous values."""
-    if value is None:
-        return False
-    if isinstance(value, bool):
-        return value
-    raise ValueError(f"`{key}` must be true or false, got {value!r}")
-
-
 def process_config(config_path: Path) -> Dict[str, Any]:
     """Parse and validate a YAML file for the beneficiaries workflow.
 
@@ -300,10 +291,12 @@ def process_config(config_path: Path) -> Dict[str, Any]:
         pattern for pattern in _as_list(inputs.get("aoi_vector_pattern", []))
         if pattern
     ]
-    analyze_full_raster_extent = _optional_bool(
-        inputs.get("analyze_full_raster_extent", False),
-        "inputs.analyze_full_raster_extent",
-    )
+    analyze_full_raster_extent = inputs.get("analyze_full_raster_extent", False)
+    if not isinstance(analyze_full_raster_extent, bool):
+        raise ValueError(
+            "`inputs.analyze_full_raster_extent` must be true or false, "
+            f"got {analyze_full_raster_extent!r}"
+        )
 
     wgs84_pixel_size = inputs.get("wgs84_pixel_size", None)
     travel_time_pixel_size_m = inputs.get("travel_time_pixel_size_m", None)
@@ -564,7 +557,18 @@ def print_yaml_config(config):
 
 
 def _raster_paths_for_full_extent(config: dict) -> list[Path]:
-    """Return rasters that constrain the generated full-extent AOI."""
+    """Return rasters that constrain the generated full-extent AOI.
+
+    Args:
+        config: Normalized workflow configuration returned by
+            ``process_config``. The configuration must include input paths for
+            the population, travel-time, and DEM rasters, plus any conditional
+            raster mask sections that should limit the generated AOI extent.
+
+    Returns:
+        Ordered list of unique raster paths whose WGS84 bounds should be
+        intersected to create the generated full-raster AOI.
+    """
     inputs = config["inputs"]
     raster_paths = [
         inputs["population_raster_path"],
@@ -591,28 +595,37 @@ def _raster_paths_for_full_extent(config: dict) -> list[Path]:
     return unique_paths
 
 
-def _raster_extent_as_wgs84_box(raster_path: Path):
-    """Return the raster bounds as a WGS84 shapely box."""
-    with rasterio.open(raster_path) as raster:
-        if raster.crs is None:
-            raise ValueError(
-                f"Raster has no CRS and cannot define an extent: {raster_path}"
-            )
-        minx, miny, maxx, maxy = transform_bounds(
-            raster.crs,
-            "EPSG:4326",
-            *raster.bounds,
-            densify_pts=21,
-        )
-    return box(minx, miny, maxx, maxy)
-
-
 def create_full_raster_extent_aoi(config: dict, target_aoi_vector_path: Path) -> None:
-    """Create an AOI over the shared WGS84 bounds of all analysis rasters."""
+    """Create an AOI over the shared WGS84 bounds of all analysis rasters.
+
+    Args:
+        config: Normalized workflow configuration returned by
+            ``process_config``. The population, travel-time, DEM, and
+            conditional raster paths are used to determine the overlapping
+            raster extent.
+        target_aoi_vector_path: Path where the generated AOI GeoPackage should
+            be written.
+
+    Raises:
+        ValueError: If any raster used to define the extent has no CRS, or if
+            the rasters do not share any overlapping WGS84 bounds.
+    """
     raster_paths = _raster_paths_for_full_extent(config)
     intersection_geom = None
     for raster_path in raster_paths:
-        raster_extent = _raster_extent_as_wgs84_box(raster_path)
+        with rasterio.open(raster_path) as raster:
+            if raster.crs is None:
+                raise ValueError(
+                    "Raster has no CRS and cannot define an extent: "
+                    f"{raster_path}"
+                )
+            minx, miny, maxx, maxy = transform_bounds(
+                raster.crs,
+                "EPSG:4326",
+                *raster.bounds,
+                densify_pts=21,
+            )
+        raster_extent = box(minx, miny, maxx, maxy)
         if intersection_geom is None:
             intersection_geom = raster_extent
         else:

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -28,7 +28,12 @@ from ecoshard import taskgraph
 import psutil
 import yaml
 
-from rasterio.warp import calculate_default_transform, reproject, Resampling
+from rasterio.warp import (
+    calculate_default_transform,
+    reproject,
+    Resampling,
+    transform_bounds,
+)
 from ecoshard import geoprocessing
 from ecoshard.geoprocessing import routing
 from osgeo import gdal, osr
@@ -46,6 +51,9 @@ from pyproj import CRS, Transformer, Geod
 import shortest_distances
 
 logging.getLogger("rasterio").setLevel(logging.WARNING)
+
+
+FULL_RASTER_EXTENT_AOI_ID = "full_raster_extent"
 
 
 @dataclass
@@ -206,6 +214,15 @@ def _as_list(x: Any) -> List[Any]:
     return [x]
 
 
+def _optional_bool(value: Any, key: str) -> bool:
+    """Parse an optional YAML boolean and reject ambiguous values."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"`{key}` must be true or false, got {value!r}")
+
+
 def process_config(config_path: Path) -> Dict[str, Any]:
     """Parse and validate a YAML file for the beneficiaries workflow.
 
@@ -231,6 +248,7 @@ def process_config(config_path: Path) -> Dict[str, Any]:
                 - 'traveltime_raster_path' (str)
                 - 'subwatershed_vector_path' (str)
                 - 'aoi_vector_pattern' (list[str])
+                - 'analyze_full_raster_extent' (bool)
             - 'masks' (list[dict]): Each item has 'id' (str), 'type' (str),
               and 'params' (dict).
             - 'combine' (list[dict]): As provided in the YAML 'combine'
@@ -243,7 +261,8 @@ def process_config(config_path: Path) -> Dict[str, Any]:
             - The 'inputs' section is missing or empty.
             - Any required input is missing:
                 'population_raster_path', 'traveltime_raster_path',
-                'subwatershed_vector_path', or 'aoi_vector_pattern'.
+                'subwatershed_vector_path', or 'aoi_vector_pattern' when
+                'analyze_full_raster_extent' is not enabled.
             - Any 'sections' entry is not a mapping (dict).
             - A 'masks' or 'combine' item within 'sections' is not a dict.
             - The 'sections' block does not include both a 'masks' and
@@ -277,7 +296,14 @@ def process_config(config_path: Path) -> Dict[str, Any]:
     traveltime_raster_path = inputs.get("traveltime_raster_path", "")
     subwatershed_vector_path = inputs.get("subwatershed_vector_path", "")
     dem_raster_path = inputs.get("dem_raster_path", "")
-    aoi_vector_pattern = _as_list(inputs.get("aoi_vector_pattern", []))
+    aoi_vector_pattern = [
+        pattern for pattern in _as_list(inputs.get("aoi_vector_pattern", []))
+        if pattern
+    ]
+    analyze_full_raster_extent = _optional_bool(
+        inputs.get("analyze_full_raster_extent", False),
+        "inputs.analyze_full_raster_extent",
+    )
 
     wgs84_pixel_size = inputs.get("wgs84_pixel_size", None)
     travel_time_pixel_size_m = inputs.get("travel_time_pixel_size_m", None)
@@ -310,7 +336,12 @@ def process_config(config_path: Path) -> Dict[str, Any]:
             f"subwatershed_vector_path does not exist: {subwatershed_vector_path}"
         )
 
-    if not aoi_vector_pattern:
+    if analyze_full_raster_extent and aoi_vector_pattern:
+        missing_messages.append(
+            "aoi_vector_pattern must be empty when "
+            "analyze_full_raster_extent is true"
+        )
+    elif not analyze_full_raster_extent and not aoi_vector_pattern:
         missing_messages.append("aoi_vector_pattern is empty")
 
     if wgs84_pixel_size is None:
@@ -401,6 +432,7 @@ def process_config(config_path: Path) -> Dict[str, Any]:
             "subwatershed_vector_path": Path(subwatershed_vector_path),
             "dem_raster_path": Path(dem_raster_path),
             "aoi_vector_pattern": aoi_vector_pattern,
+            "analyze_full_raster_extent": analyze_full_raster_extent,
             "wgs84_pixel_size": float(wgs84_pixel_size),
             "travel_time_pixel_size_m": float(travel_time_pixel_size_m),
             "buffer_size_m": float(buffer_size_m),
@@ -531,6 +563,76 @@ def print_yaml_config(config):
     logger.info("  to_file: %s", config["logging"]["to_file"])
 
 
+def _raster_paths_for_full_extent(config: dict) -> list[Path]:
+    """Return rasters that constrain the generated full-extent AOI."""
+    inputs = config["inputs"]
+    raster_paths = [
+        inputs["population_raster_path"],
+        inputs["traveltime_raster_path"],
+        inputs["dem_raster_path"],
+    ]
+    for mask_section in config["masks"]:
+        if mask_section["type"] != "conditional_raster":
+            continue
+        condition_raster_path = mask_section.get("params", {}).get(
+            "condition_raster_path"
+        )
+        if condition_raster_path:
+            raster_paths.append(Path(condition_raster_path))
+
+    unique_paths = []
+    seen_paths = set()
+    for raster_path in raster_paths:
+        path = Path(raster_path)
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        unique_paths.append(path)
+    return unique_paths
+
+
+def _raster_extent_as_wgs84_box(raster_path: Path):
+    """Return the raster bounds as a WGS84 shapely box."""
+    with rasterio.open(raster_path) as raster:
+        if raster.crs is None:
+            raise ValueError(
+                f"Raster has no CRS and cannot define an extent: {raster_path}"
+            )
+        minx, miny, maxx, maxy = transform_bounds(
+            raster.crs,
+            "EPSG:4326",
+            *raster.bounds,
+            densify_pts=21,
+        )
+    return box(minx, miny, maxx, maxy)
+
+
+def create_full_raster_extent_aoi(config: dict, target_aoi_vector_path: Path) -> None:
+    """Create an AOI over the shared WGS84 bounds of all analysis rasters."""
+    raster_paths = _raster_paths_for_full_extent(config)
+    intersection_geom = None
+    for raster_path in raster_paths:
+        raster_extent = _raster_extent_as_wgs84_box(raster_path)
+        if intersection_geom is None:
+            intersection_geom = raster_extent
+        else:
+            intersection_geom = intersection_geom.intersection(raster_extent)
+
+        if intersection_geom.is_empty:
+            raise ValueError(
+                "No shared raster extent remains after intersecting "
+                f"{raster_path}."
+            )
+
+    target_aoi_vector_path.parent.mkdir(parents=True, exist_ok=True)
+    aoi_gdf = gpd.GeoDataFrame(
+        {"id": [FULL_RASTER_EXTENT_AOI_ID]},
+        geometry=[intersection_geom],
+        crs="EPSG:4326",
+    )
+    aoi_gdf.to_file(target_aoi_vector_path, driver="GPKG")
+
+
 def collect_aoi_files(config: dict) -> dict[str, Path]:
     """Collect AOI files from the patterns.
 
@@ -543,6 +645,15 @@ def collect_aoi_files(config: dict) -> dict[str, Path]:
         ValueError if two or more files share the same stem.
     """
     inputs = config.get("inputs", {})
+    if inputs.get("analyze_full_raster_extent", False):
+        target_aoi_vector_path = (
+            Path(config["work_dir"])
+            / "_generated_aois"
+            / f"{FULL_RASTER_EXTENT_AOI_ID}.gpkg"
+        )
+        create_full_raster_extent_aoi(config, target_aoi_vector_path)
+        return {FULL_RASTER_EXTENT_AOI_ID: target_aoi_vector_path.resolve()}
+
     patterns = inputs.get("aoi_vector_pattern", [])
     if not isinstance(patterns, (list, tuple)):
         patterns = [patterns]
@@ -559,6 +670,13 @@ def collect_aoi_files(config: dict) -> dict[str, Path]:
                     f"  - {path}"
                 )
             aoi_map[stem] = path
+    if not aoi_map:
+        raise ValueError(
+            "No AOI files matched aoi_vector_pattern. To intentionally analyze "
+            "the full overlapping raster extent, set "
+            "inputs.analyze_full_raster_extent: true and leave "
+            "aoi_vector_pattern empty."
+        )
     return aoi_map
 
 


### PR DESCRIPTION
## Summary
- Add an explicit `inputs.analyze_full_raster_extent: true` option for workflows that intentionally omit AOI vectors.
- Generate one synthetic `full_raster_extent` AOI from the shared WGS84 bounds of population, travel-time, DEM, and conditional rasters.
- Keep the default AOI pattern requirement in place unless the new explicit flag is enabled.
- Document the option in the README and sample config.

Closes #27.

## Testing
- `python -m py_compile workflow_runner.py potential_beneficiaries_target.py utils/chunk_file.py`
- `git diff --check`