### PR TITLE
Reduce memory use on global runs

### DIFF
--- a/shortest_distances/src/shortest_distances.pyx
+++ b/shortest_distances/src/shortest_distances.pyx
@@ -24,7 +24,7 @@ import numpy
 
 cimport cython
 cimport numpy
-from libc.math cimport sqrtf
+from libc.math cimport sqrt
 from libc.time cimport time as ctime
 from libc.time cimport time_t
 from libcpp.deque cimport deque
@@ -96,14 +96,14 @@ def find_mask_reach(
     cdef int i, j
     cdef numpy.ndarray[numpy.uint8_t, ndim=2] mask_coverage = numpy.zeros(
         (n_rows, n_cols), dtype=numpy.uint8)
-    cdef numpy.ndarray[float, ndim=2] current_time = numpy.where(
-        mask_array == 1, 0, numpy.inf).astype(numpy.float32)
+    cdef numpy.ndarray[float, ndim=2] current_time
 
-    cdef float diag_cell_length_m = sqrtf(<float>(2*cell_length_m*cell_length_m))
+    cdef float diag_cell_length_m = <float>sqrt(
+        <double>(2*cell_length_m*cell_length_m))
     cdef float frict_n, c_time, n_time, edge_weight
     cdef int i_start, j_start, i_n, j_n
-    cdef int min_i, min_j, max_i, max_j
-    cdef int mask_val
+    cdef int v
+    cdef bint is_frontier
 
     cdef DistPriorityQueueType dist_queue
     cdef ValuePixelType pixel
@@ -114,66 +114,77 @@ def find_mask_reach(
                     continue
                 mask_coverage[j_start, i_start] = 1
 
+                is_frontier = False
+                for v in range(8):
+                    i_n = i_start+ioff[v]
+                    j_n = j_start+joff[v]
+                    if i_n < 0 or i_n >= n_cols:
+                        continue
+                    if j_n < 0 or j_n >= n_rows:
+                        continue
+                    if mask_array[j_n, i_n] != 0:
+                        continue
+                    if friction_array[j_n, i_n] <= 0:
+                        continue
+                    is_frontier = True
+                    break
+
+                if not is_frontier:
+                    continue
+
                 pixel.t_time = 0
                 pixel.edge_weight = 0
                 pixel.i = i_start
                 pixel.j = j_start
                 dist_queue.push(pixel)
-                min_i = i_start
-                max_i = i_start
-                min_j = j_start
-                max_j = j_start
 
-                # c_ -- current, n_ -- neighbor
-                while dist_queue.size() > 0:
-                    pixel = dist_queue.top()
-                    dist_queue.pop()
-                    c_time = pixel.t_time
-                    i = pixel.i
-                    j = pixel.j
-                    if c_time > current_time[j, i]:
-                        # this means another path already reached here that's
-                        # better
-                        continue
-                    mask_coverage[j, i] = 1
-                    if i < min_i:
-                        min_i = i
-                    elif i > max_i:
-                        max_i = i
-                    if j < min_j:
-                        min_j = j
-                    elif j > max_j:
-                        max_j = j
+    if dist_queue.empty():
+        return mask_coverage
 
-                    for v in range(8):
-                        i_n = i+ioff[v]
-                        j_n = j+joff[v]
-                        if i_n < 0 or i_n >= n_cols:
-                            continue
-                        if j_n < 0 or j_n >= n_rows:
-                            continue
-                        if mask_array[j_n, i_n] < 0:
-                            # nodata, so skip
-                            continue
-                        frict_n = friction_array[j_n, i_n]
-                        # the nodata value is undefined but will present as 0.
-                        if frict_n <= 0:
-                            continue
-                        if v & 1:  # if msd is 1, it's odd
-                            edge_weight = frict_n*diag_cell_length_m
-                        else:
-                            edge_weight = frict_n*cell_length_m
+    current_time = numpy.full((n_rows, n_cols), max_time+1, dtype=numpy.float32)
 
-                        n_time = c_time + edge_weight
-                        if n_time > max_time:
-                            continue
-                        # if visited before and we got there faster, then skip
-                        if n_time >= current_time[j_n, i_n]:
-                            continue
-                        current_time[j_n, i_n] = n_time
-                        pixel.t_time = n_time
-                        pixel.edge_weight = edge_weight
-                        pixel.i = i_n
-                        pixel.j = j_n
-                        dist_queue.push(pixel)
+    with nogil:
+        # c_ -- current, n_ -- neighbor
+        while dist_queue.size() > 0:
+            pixel = dist_queue.top()
+            dist_queue.pop()
+            c_time = pixel.t_time
+            i = pixel.i
+            j = pixel.j
+            if mask_array[j, i] != 1 and c_time > current_time[j, i]:
+                # this means another path already reached here that's better
+                continue
+            mask_coverage[j, i] = 1
+
+            for v in range(8):
+                i_n = i+ioff[v]
+                j_n = j+joff[v]
+                if i_n < 0 or i_n >= n_cols:
+                    continue
+                if j_n < 0 or j_n >= n_rows:
+                    continue
+                if mask_array[j_n, i_n] != 0:
+                    # nodata or source cells are already covered
+                    continue
+                frict_n = friction_array[j_n, i_n]
+                # the nodata value is undefined but will present as 0.
+                if frict_n <= 0:
+                    continue
+                if v & 1:  # if msd is 1, it's odd
+                    edge_weight = frict_n*diag_cell_length_m
+                else:
+                    edge_weight = frict_n*cell_length_m
+
+                n_time = c_time + edge_weight
+                if n_time > max_time:
+                    continue
+                # if visited before and we got there faster, then skip
+                if n_time >= current_time[j_n, i_n]:
+                    continue
+                current_time[j_n, i_n] = n_time
+                pixel.t_time = n_time
+                pixel.edge_weight = edge_weight
+                pixel.i = i_n
+                pixel.j = j_n
+                dist_queue.push(pixel)
     return mask_coverage

--- a/shortest_distances/src/shortest_distances.pyx
+++ b/shortest_distances/src/shortest_distances.pyx
@@ -77,7 +77,8 @@ def find_mask_reach(
         numpy.ndarray[numpy.int8_t, ndim=2] mask_array,
         float cell_length_m,
         int n_cols, int n_rows,
-        float max_time):
+        float max_time,
+        int progress_interval_seconds=10):
     """Define later
 
     Parameters:
@@ -88,6 +89,9 @@ def find_mask_reach(
         n_cols/n_rows (int): number of cells in i/j direction of given arrays.
         max_time (float): the time allowed when computing population reach
             in minutes.
+        progress_interval_seconds (int): minimum number of seconds between
+            travel-reach heartbeat log messages. Set to 0 to disable progress
+            logging.
 
     Returns:
         2D array of mask reach of the same size as input arrays.
@@ -104,15 +108,35 @@ def find_mask_reach(
     cdef int i_start, j_start, i_n, j_n
     cdef int v
     cdef bint is_frontier
+    cdef unsigned long long covered_count = 0
+    cdef unsigned long long pop_count = 0
+    cdef unsigned long long frontier_source_count = 0
+    cdef unsigned long long heartbeat_count = 0
+    cdef unsigned long long progress_check_interval = 100000
+    cdef unsigned long long next_progress_check = progress_check_interval
+    cdef time_t start_time = ctime(NULL)
+    cdef time_t last_report_time = start_time
+    cdef time_t report_time
+    cdef double elapsed_seconds = 0
+    cdef double pop_rate = 0
+    cdef double frontier_percent = 0
+    cdef size_t queue_size
+    cdef bint report_needed = False
 
     cdef DistPriorityQueueType dist_queue
     cdef ValuePixelType pixel
+    if progress_interval_seconds > 0:
+        LOGGER.info(
+            "preparing travel reach frontier; raster=%sx%s px, "
+            "max_time=%.1f min",
+            n_cols, n_rows, max_time)
     with nogil:
         for i_start in range(n_cols):
             for j_start in range(n_rows):
                 if mask_array[j_start, i_start] != 1:
                     continue
                 mask_coverage[j_start, i_start] = 1
+                covered_count += 1
 
                 is_frontier = False
                 for v in range(8):
@@ -137,54 +161,113 @@ def find_mask_reach(
                 pixel.i = i_start
                 pixel.j = j_start
                 dist_queue.push(pixel)
+                frontier_source_count += 1
 
     if dist_queue.empty():
+        if progress_interval_seconds > 0:
+            LOGGER.info(
+                "travel reach completed without expansion; covered=%s px",
+                covered_count)
         return mask_coverage
 
     current_time = numpy.full((n_rows, n_cols), max_time+1, dtype=numpy.float32)
+    if progress_interval_seconds > 0:
+        LOGGER.info(
+            "starting travel reach expansion; frontier_sources=%s, "
+            "covered_sources=%s px, max_time=%.1f min",
+            frontier_source_count, covered_count, max_time)
 
-    with nogil:
-        # c_ -- current, n_ -- neighbor
-        while dist_queue.size() > 0:
-            pixel = dist_queue.top()
-            dist_queue.pop()
-            c_time = pixel.t_time
-            i = pixel.i
-            j = pixel.j
-            if mask_array[j, i] != 1 and c_time > current_time[j, i]:
-                # this means another path already reached here that's better
-                continue
-            mask_coverage[j, i] = 1
+    while dist_queue.size() > 0:
+        report_needed = False
+        with nogil:
+            # c_ -- current, n_ -- neighbor
+            while dist_queue.size() > 0:
+                pixel = dist_queue.top()
+                dist_queue.pop()
+                pop_count += 1
+                c_time = pixel.t_time
+                i = pixel.i
+                j = pixel.j
 
-            for v in range(8):
-                i_n = i+ioff[v]
-                j_n = j+joff[v]
-                if i_n < 0 or i_n >= n_cols:
-                    continue
-                if j_n < 0 or j_n >= n_rows:
-                    continue
-                if mask_array[j_n, i_n] != 0:
-                    # nodata or source cells are already covered
-                    continue
-                frict_n = friction_array[j_n, i_n]
-                # the nodata value is undefined but will present as 0.
-                if frict_n <= 0:
-                    continue
-                if v & 1:  # if msd is 1, it's odd
-                    edge_weight = frict_n*diag_cell_length_m
-                else:
-                    edge_weight = frict_n*cell_length_m
+                if (progress_interval_seconds > 0 and
+                        pop_count >= next_progress_check):
+                    next_progress_check = pop_count + progress_check_interval
+                    report_time = ctime(NULL)
+                    if report_time - last_report_time >= progress_interval_seconds:
+                        last_report_time = report_time
+                        heartbeat_count += 1
+                        elapsed_seconds = <double>(report_time - start_time)
+                        if elapsed_seconds > 0:
+                            pop_rate = pop_count / elapsed_seconds
+                        else:
+                            pop_rate = 0
+                        if max_time > 0:
+                            frontier_percent = 100.0 * c_time / max_time
+                        else:
+                            frontier_percent = 0
+                        report_needed = True
 
-                n_time = c_time + edge_weight
-                if n_time > max_time:
+                if mask_array[j, i] != 1 and c_time > current_time[j, i]:
+                    # this means another path already reached here that's better
+                    if report_needed:
+                        queue_size = dist_queue.size()
+                        break
                     continue
-                # if visited before and we got there faster, then skip
-                if n_time >= current_time[j_n, i_n]:
-                    continue
-                current_time[j_n, i_n] = n_time
-                pixel.t_time = n_time
-                pixel.edge_weight = edge_weight
-                pixel.i = i_n
-                pixel.j = j_n
-                dist_queue.push(pixel)
+                if mask_coverage[j, i] == 0:
+                    covered_count += 1
+                mask_coverage[j, i] = 1
+
+                for v in range(8):
+                    i_n = i+ioff[v]
+                    j_n = j+joff[v]
+                    if i_n < 0 or i_n >= n_cols:
+                        continue
+                    if j_n < 0 or j_n >= n_rows:
+                        continue
+                    if mask_array[j_n, i_n] != 0:
+                        # nodata or source cells are already covered
+                        continue
+                    frict_n = friction_array[j_n, i_n]
+                    # the nodata value is undefined but will present as 0.
+                    if frict_n <= 0:
+                        continue
+                    if v & 1:  # if msd is 1, it's odd
+                        edge_weight = frict_n*diag_cell_length_m
+                    else:
+                        edge_weight = frict_n*cell_length_m
+
+                    n_time = c_time + edge_weight
+                    if n_time > max_time:
+                        continue
+                    # if visited before and we got there faster, then skip
+                    if n_time >= current_time[j_n, i_n]:
+                        continue
+                    current_time[j_n, i_n] = n_time
+                    pixel.t_time = n_time
+                    pixel.edge_weight = edge_weight
+                    pixel.i = i_n
+                    pixel.j = j_n
+                    dist_queue.push(pixel)
+
+                if report_needed:
+                    queue_size = dist_queue.size()
+                    break
+        if report_needed:
+            LOGGER.info(
+                "travel reach heartbeat: frontier=%.1f/%.1f min "
+                "(%.1f%% of limit), covered=%s px, queue=%s, "
+                "pops=%s, rate=%.0f pops/s, elapsed=%.0fs",
+                c_time, max_time, frontier_percent, covered_count,
+                queue_size, pop_count, pop_rate, elapsed_seconds)
+    if progress_interval_seconds > 0:
+        elapsed_seconds = <double>(ctime(NULL) - start_time)
+        if elapsed_seconds > 0:
+            pop_rate = pop_count / elapsed_seconds
+        else:
+            pop_rate = 0
+        LOGGER.info(
+            "travel reach complete: covered=%s px, pops=%s, "
+            "rate=%.0f pops/s, elapsed=%.0fs, heartbeats=%s",
+            covered_count, pop_count, pop_rate, elapsed_seconds,
+            heartbeat_count)
     return mask_coverage

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -289,8 +289,7 @@ def process_config(config_path: Path) -> Dict[str, Any]:
     subwatershed_vector_path = inputs.get("subwatershed_vector_path", "")
     dem_raster_path = inputs.get("dem_raster_path", "")
     aoi_vector_pattern = [
-        pattern for pattern in _as_list(inputs.get("aoi_vector_pattern", []))
-        if pattern
+        pattern for pattern in _as_list(inputs.get("aoi_vector_pattern", [])) if pattern
     ]
     analyze_full_raster_extent = inputs.get("analyze_full_raster_extent", False)
     if not isinstance(analyze_full_raster_extent, bool):
@@ -643,8 +642,7 @@ def create_full_raster_extent_aoi(config: dict, target_aoi_vector_path: Path) ->
         with rasterio.open(raster_path) as raster:
             if raster.crs is None:
                 raise ValueError(
-                    "Raster has no CRS and cannot define an extent: "
-                    f"{raster_path}"
+                    "Raster has no CRS and cannot define an extent: " f"{raster_path}"
                 )
             minx, miny, maxx, maxy = transform_bounds(
                 raster.crs,
@@ -660,8 +658,7 @@ def create_full_raster_extent_aoi(config: dict, target_aoi_vector_path: Path) ->
 
         if intersection_geom.is_empty:
             raise ValueError(
-                "No shared raster extent remains after intersecting "
-                f"{raster_path}."
+                "No shared raster extent remains after intersecting " f"{raster_path}."
             )
 
     target_aoi_vector_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1556,6 +1553,15 @@ def combine_pops(
             result = np.maximum(result, value_array)
         return result
 
+    def raster_sum(raster_path):
+        total = np.float64(0)
+        for _, block in geoprocessing.iterblocks(
+            (str(raster_path), 1),
+            largest_block=10 * 2**20,
+        ):
+            total += np.sum(block, dtype=np.float64)
+        return total
+
     raster_ids = [raster_id for raster_id, _ in pop_id_raster_list]
     base_pop_raster_list = [str(path) for _, path in pop_id_raster_list]
 
@@ -1579,13 +1585,10 @@ def combine_pops(
         target_projection_wkt=wgs84_wkt,
     )
 
-    aligned_pop_sums_by_id = {}
-    for raster_id, aligned_path in zip(raster_ids, aligned_pop_raster_list):
-        raster = gdal.OpenEx(aligned_path)
-        array = raster.ReadAsArray()
-        raster = None
-        aligned_pop_sums_by_id[raster_id] = np.sum(array)
-        array = None
+    aligned_pop_sums_by_id = {
+        raster_id: raster_sum(aligned_path)
+        for raster_id, aligned_path in zip(raster_ids, aligned_pop_raster_list)
+    }
 
     geoprocessing.raster_calculator(
         [(str(path), 1) for path in aligned_pop_raster_list],
@@ -1593,13 +1596,10 @@ def combine_pops(
         target_combined_pop_raster_path,
         gdal.GDT_Float32,
         None,
+        largest_block=10 * 2**20,
     )
 
-    raster = gdal.OpenEx(target_combined_pop_raster_path)
-    array = raster.ReadAsArray()
-    raster = None
-    aligned_pop_sums_by_id["combined pop"] = np.sum(array)
-    array = None
+    aligned_pop_sums_by_id["combined pop"] = raster_sum(target_combined_pop_raster_path)
 
     return aligned_pop_sums_by_id
 

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -722,6 +722,16 @@ def _chunks(iterable, size):
     return iter(lambda: list(islice(it, size)), [])
 
 
+def _sum_raster_blocks(raster_path):
+    total = np.float64(0)
+    for _, block in geoprocessing.iterblocks(
+        (str(raster_path), 1),
+        largest_block=10 * 2**20,
+    ):
+        total += np.sum(block, dtype=np.float64)
+    return total
+
+
 def subset_subwatersheds(
     aoi_vector_path: str | Path,
     subwatershed_vector_path: str | Path,
@@ -1234,7 +1244,6 @@ def apply_travel_time_mask(
 
     with rasterio.open(target_pop_clipped_raster_path) as pop_ref:
         ref_meta = pop_ref.meta.copy()
-        pop_array = pop_ref.read(1)
 
     _clip_and_reproject_raster(
         traveltime_raster_path,
@@ -1275,16 +1284,23 @@ def apply_travel_time_mask(
     with rasterio.open(target_max_reach_raster_path, "w", **aoi_meta) as max_reach:
         max_reach.write(travel_reach_array, 1)
 
-    pop_meta = ref_meta.copy()
-    pop_meta.update(
-        {"count": 1, "dtype": rasterio.int32, "nodata": 0, "compress": "lzw"}
+    travel_reach_array = None
+
+    def mask_op(mask, pop_val):
+        return np.where((mask > 0) & (pop_val > 0), pop_val, 0)
+
+    geoprocessing.raster_calculator(
+        [
+            (str(target_max_reach_raster_path), 1),
+            (str(target_pop_clipped_raster_path), 1),
+        ],
+        mask_op,
+        target_pop_raster_path,
+        gdal.GDT_Int32,
+        0,
+        largest_block=10 * 2**20,
     )
-    pop_masked_array = np.where(
-        (travel_reach_array > 0) & (pop_array > 0), pop_array, 0
-    )
-    with rasterio.open(target_pop_raster_path, "w", **pop_meta) as dst:
-        dst.write(pop_masked_array, 1)
-    return np.sum(pop_masked_array)
+    return _sum_raster_blocks(target_pop_raster_path)
 
 
 def create_distance_transform(base_mask_raster_path, target_distance_transform_path):
@@ -1553,15 +1569,6 @@ def combine_pops(
             result = np.maximum(result, value_array)
         return result
 
-    def raster_sum(raster_path):
-        total = np.float64(0)
-        for _, block in geoprocessing.iterblocks(
-            (str(raster_path), 1),
-            largest_block=10 * 2**20,
-        ):
-            total += np.sum(block, dtype=np.float64)
-        return total
-
     raster_ids = [raster_id for raster_id, _ in pop_id_raster_list]
     base_pop_raster_list = [str(path) for _, path in pop_id_raster_list]
 
@@ -1586,7 +1593,7 @@ def combine_pops(
     )
 
     aligned_pop_sums_by_id = {
-        raster_id: raster_sum(aligned_path)
+        raster_id: _sum_raster_blocks(aligned_path)
         for raster_id, aligned_path in zip(raster_ids, aligned_pop_raster_list)
     }
 
@@ -1599,7 +1606,9 @@ def combine_pops(
         largest_block=10 * 2**20,
     )
 
-    aligned_pop_sums_by_id["combined pop"] = raster_sum(target_combined_pop_raster_path)
+    aligned_pop_sums_by_id["combined pop"] = _sum_raster_blocks(
+        target_combined_pop_raster_path
+    )
 
     return aligned_pop_sums_by_id
 


### PR DESCRIPTION
## Summary
- Preserve the existing blockwise population summing fix for combined outputs.
- Change `shortest_distances.find_mask_reach` from repeated per-source Dijkstra expansion to one multi-source expansion seeded from source-mask frontier pixels.
- Return immediately when the source mask has no valid frontier, avoiding the dense travel-time distance array for full-raster/full-source cases.
- Avoid reading the clipped population raster into RAM before `find_mask_reach`; calculate the final travel-time-masked population raster and sum it blockwise.
- Add coarse travel-reach heartbeat logging with frontier prep, covered pixels, queue size, queue pops, pop rate, elapsed time, and frontier travel time.
- Use `sqrt` instead of `sqrtf` in the Cython module for broader Cython compatibility.

Closes #35

## Testing
- `python -m py_compile workflow_runner.py`
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile workflow_runner.py`
- `git diff --check`
- `C:\Users\richp\.conda\envs\py39\python.exe -m cython --cplus src\shortest_distances.pyx -o src\shortest_distances.cpp`
- Explicit MSVC py39 compile/link of the generated `shortest_distances` extension.
- Cython smoke tests comparing `find_mask_reach` outputs against a Python translation of the previous algorithm on small masks, multi-pixel source masks, all-source masks, nodata, and varied friction.
- Cython smoke tests for the heartbeat commit covering a reachable-mask case, all-source/no-frontier case, and progress-enabled call path.

## Notes
- Classic shared-priority-queue Dijkstra is not a simple thread-parallel target. This change focuses on reducing repeated queue work and avoiding dense allocations when no expansion is needed.
- On this Windows machine, `setup.py build_ext --inplace` can pick up Cygwin `link.exe`; the latest Cython verification used explicit MSVC paths to avoid that local PATH conflict.