### PR TITLE
Keep console logs from corrupting progress bars

### DIFF
--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -57,6 +57,20 @@ logging.getLogger("rasterio").setLevel(logging.WARNING)
 FULL_RASTER_EXTENT_AOI_ID = "full_raster_extent"
 
 
+class TqdmLoggingHandler(logging.StreamHandler):
+    """Write console logs without corrupting active tqdm progress bars."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+            tqdm.write(msg, file=self.stream)
+            self.flush()
+        except RecursionError:
+            raise
+        except Exception:
+            self.handleError(record)
+
+
 @dataclass
 class PickedCRS:
     """Used to define a return type for CRS."""
@@ -464,7 +478,7 @@ def setup_logger(level: str, log_file: str) -> logging.Logger:
 
     fmt = "%(asctime)s %(filename)s:%(lineno)d [%(levelname)s]  %(message)s"
 
-    sh = logging.StreamHandler(sys.stdout)
+    sh = TqdmLoggingHandler(sys.stdout)
     sh.setFormatter(logging.Formatter(fmt))
     root_logger.addHandler(sh)
 
@@ -472,6 +486,8 @@ def setup_logger(level: str, log_file: str) -> logging.Logger:
         fh = logging.FileHandler(log_file, mode="w", encoding="utf-8")
         fh.setFormatter(logging.Formatter(fmt))
         root_logger.addHandler(fh)
+
+    logging.getLogger("pyogrio").setLevel(logging.WARNING)
 
     return root_logger
 


### PR DESCRIPTION
## Summary
- Route console logging through a `tqdm.write`-based handler so log records do not overwrite active progress bars.
- Quiet pyogrio INFO logging to avoid repeated `Created N records` messages while writing drain partition files.

Closes #37

## Testing
- `python -m py_compile workflow_runner.py`
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile workflow_runner.py`
- `C:\Users\richp\mambaforge\envs\py311\python.exe -` smoke test for `setup_logger`, the tqdm logging handler, and the pyogrio logger level.
- `git diff --check`

## Notes
- The local py311 smoke test emitted GDAL_DATA warnings during import, before workflow logging setup runs; the logger behavior under test passed.