### PR TITLE
Fix shortest_distances extension install

### DIFF
--- a/shortest_distances/pyproject.toml
+++ b/shortest_distances/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "cython", "numpy"]
+requires = ["setuptools>=61", "setuptools_scm[toml]", "cython", "numpy"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,3 +7,4 @@ name = "shortest_distances"
 dynamic = ["version"]
 
 [tool.setuptools_scm]
+root = ".."


### PR DESCRIPTION
## Summary
- Add `setuptools_scm[toml]` to the `shortest_distances` isolated build requirements.
- Point `setuptools_scm` at the parent repository root so package builds from the `shortest_distances/` subdirectory can find git metadata.
- Restores normal installed imports so `shortest_distances.find_mask_reach` is available from the compiled extension.

Closes #41.

## Testing
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m pip install --target .\_tmp_shortest_distances_install --no-deps .\shortest_distances`
- `C:\Users\richp\mambaforge\envs\py311\python.exe -c "import sys; sys.path.insert(0, r'D:\repositories\wwf_es_beneficiaries\_tmp_shortest_distances_install'); import shortest_distances; print(shortest_distances.__file__); print(hasattr(shortest_distances, 'find_mask_reach'))"`
  - Confirmed import resolves to `shortest_distances.cp311-win_amd64.pyd`
  - Confirmed `hasattr(shortest_distances, 'find_mask_reach') == True`
- `git diff --check`

## Notes
- No workflow behavior changes; this is limited to the Cython extension package build metadata.