### PR TITLE
Preserve nodata during clip reprojection

### DIFF
--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1212,6 +1212,11 @@ def _clip_and_reproject_raster(
             }
         )
 
+        reproject_kwargs = {}
+        if src.nodata is not None:
+            reproject_kwargs["src_nodata"] = src.nodata
+            reproject_kwargs["dst_nodata"] = src.nodata
+
         with rasterio.open(target_raster_path, "w", **out_meta) as dst:
             reproject(
                 source=out_image,
@@ -1221,6 +1226,7 @@ def _clip_and_reproject_raster(
                 dst_transform=dst_transform,
                 dst_crs=dst_crs,
                 resampling=Resampling.nearest,
+                **reproject_kwargs,
             )
 
 


### PR DESCRIPTION
## Summary
- Pass explicit `src_nodata` and `dst_nodata` to Rasterio `reproject` when `_clip_and_reproject_raster` is working from a masked NumPy array.
- Keeps source nodata values reserved as nodata during travel-time clip/reprojection instead of letting GDAL treat them as valid pixels that need to be shifted away from destination nodata.

Closes #43.

## Testing
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile workflow_runner.py`
- Ran a targeted `_clip_and_reproject_raster` check with a small Int32 raster using `nodata=-1`; confirmed the output nodata remained `-1`, output retained three `-1` nodata pixels, and output contained zero `-2` pixels.
- `git diff --check`

## Notes
- The local environment still emits GDAL_DATA warnings on import (`Cannot find gdalvrt.xsd`, `Cannot find header.dxf`), which appear unrelated to this nodata reprojection fix.