### PR TITLE
Disable stats for derived workflow rasters

### DIFF
--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1343,6 +1343,7 @@ def apply_travel_time_mask(
         gdal.GDT_Int32,
         0,
         largest_block=10 * 2**20,
+        calc_raster_stats=False,
     )
     return _sum_raster_blocks(target_pop_raster_path)
 
@@ -1513,6 +1514,7 @@ def calculate_ds_pop_from_conditional_raster(
         condition_raster_path,
         gdal.GDT_Byte,
         None,
+        calc_raster_stats=False,
     )
 
     ds_coverage_raster_path = str(
@@ -1569,6 +1571,7 @@ def calculate_ds_pop_from_conditional_raster(
             maxdist_buffered_ds_coverage_raster_path,
             gdal.GDT_Byte,
             None,
+            calc_raster_stats=False,
         )
         buffered_ds_coverage_raster_path = maxdist_buffered_ds_coverage_raster_path
 
@@ -1587,6 +1590,7 @@ def calculate_ds_pop_from_conditional_raster(
         target_pop_raster_path,
         pop_info["datatype"],
         None,
+        calc_raster_stats=False,
     )
     return np.sum(gdal.OpenEx(target_pop_raster_path).ReadAsArray())
 
@@ -1648,6 +1652,7 @@ def combine_pops(
         gdal.GDT_Float32,
         None,
         largest_block=10 * 2**20,
+        calc_raster_stats=False,
     )
 
     aligned_pop_sums_by_id["combined pop"] = _sum_raster_blocks(


### PR DESCRIPTION
## Summary
- Disable `geoprocessing.raster_calculator` statistics for workflow-derived rasters where stats are not consumed.
- Covers travel-time population outputs, conditional masks, distance-limited coverage masks, conditional partition population rasters, and combined population rasters.
- Reduces repeated ecoshard stats-worker warnings for empty/all-nodata partition outputs and avoids unnecessary stats work.

Closes #45.

## Testing
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile workflow_runner.py`
- `git diff --check`

## Notes
- This does not address stats warnings emitted by raster calculators inside ecoshard internals, such as vector-mask work inside `align_and_resize_raster_stack`; it only disables stats on raster calculator calls owned directly by this workflow.