### PR TITLE
Tile travel-time workflow rasters

### DIFF
--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -54,8 +54,8 @@ import shortest_distances
 RASTER_BLOCK_SIZE = 256
 
 
-def _set_tiled_raster_options(raster_meta: dict) -> None:
-    """Update a Rasterio metadata dict for block-aligned GeoTIFF writes."""
+def _set_tiled_geotiff_creation_options(raster_meta: dict) -> None:
+    """Set Rasterio creation options for block-aligned GeoTIFF writes."""
     raster_meta.update(
         {
             "tiled": True,
@@ -1227,7 +1227,7 @@ def _clip_and_reproject_raster(
                 "height": height,
             }
         )
-        _set_tiled_raster_options(out_meta)
+        _set_tiled_geotiff_creation_options(out_meta)
 
         reproject_kwargs = {}
         if src.nodata is not None:
@@ -1326,7 +1326,7 @@ def apply_travel_time_mask(
     aoi_meta.update(
         {"count": 1, "dtype": rasterio.uint8, "nodata": 0, "compress": "lzw"}
     )
-    _set_tiled_raster_options(aoi_meta)
+    _set_tiled_geotiff_creation_options(aoi_meta)
 
     with rasterio.open(target_aoi_raster_path, "w", **aoi_meta) as dst:
         dst.write(mask_array, 1)

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -51,6 +51,22 @@ from tqdm.auto import tqdm
 
 import shortest_distances
 
+RASTER_BLOCK_SIZE = 256
+
+
+def _set_tiled_raster_options(raster_meta: dict) -> None:
+    """Update a Rasterio metadata dict for block-aligned GeoTIFF writes."""
+    raster_meta.update(
+        {
+            "tiled": True,
+            "blockxsize": RASTER_BLOCK_SIZE,
+            "blockysize": RASTER_BLOCK_SIZE,
+            "compress": "lzw",
+            "BIGTIFF": "YES",
+        }
+    )
+
+
 QUIET_LOGGER_NAMES = [
     "ecoshard",
     "ecoshard.taskgraph",
@@ -1211,6 +1227,7 @@ def _clip_and_reproject_raster(
                 "height": height,
             }
         )
+        _set_tiled_raster_options(out_meta)
 
         reproject_kwargs = {}
         if src.nodata is not None:
@@ -1309,6 +1326,7 @@ def apply_travel_time_mask(
     aoi_meta.update(
         {"count": 1, "dtype": rasterio.uint8, "nodata": 0, "compress": "lzw"}
     )
+    _set_tiled_raster_options(aoi_meta)
 
     with rasterio.open(target_aoi_raster_path, "w", **aoi_meta) as dst:
         dst.write(mask_array, 1)


### PR DESCRIPTION
## Summary
- Add a shared Rasterio metadata helper for 256x256 tiled, LZW-compressed GeoTIFF writes.
- Apply it to travel-time clip/reproject outputs and travel-time AOI/max-reach rasters.
- Keeps Rasterio-created travel-time rasters block-aligned with ecoshard/geoprocessing's default 256x256 raster calculator output blocks.

Closes #47.

## Testing
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile workflow_runner.py`
- Ran a targeted `_clip_and_reproject_raster` check with a small source raster; confirmed output `block_shapes == [(256, 256)]` and tiled profile metadata is set.
- `git diff --check`

## Notes
- This keeps `geoprocessing.raster_calculator` blocksize enforcement intact instead of using `allow_different_blocksize=True`.
- The local environment still emits unrelated GDAL_DATA warnings on import (`Cannot find gdalvrt.xsd`, `Cannot find header.dxf`).