### PR TITLE
Use supported WarpedVRT nodata option

### DIFF
--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1981,7 +1981,7 @@ def combine_pops(
                             "width": target.width,
                             "height": target.height,
                             "resampling": Resampling.nearest,
-                            "dst_nodata": 0,
+                            "nodata": 0,
                         }
                         if source.nodata is not None:
                             vrt_kwargs["src_nodata"] = source.nodata


### PR DESCRIPTION
## Summary
- Replace the `WarpedVRT` `dst_nodata` argument with the supported `nodata` argument in the population combine step.
- Leave the existing `rasterio.warp.reproject` `dst_nodata` usage unchanged, since that API supports it.

Closes #57

## Testing
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m py_compile workflow_runner.py`
- `git diff --check`
- `WarpedVRT` smoke test with an in-memory raster verified the warning output does not include `DST_NODATA` when using `nodata=0`.

## Notes
- The smoke test still emitted the local environment warning that `GDAL_DATA` is not defined; that is separate from the unsupported `DST_NODATA` warning fixed here.