### PR TITLE
Avoid zero nodata in population combine

### DIFF
--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -61,6 +61,7 @@ import shortest_distances
 RASTER_BLOCK_SIZE = 256
 HEARTBEAT_INTERVAL_SECONDS = 60
 TRAVEL_TIME_MAX_DISTANCE_M_PER_HOUR = 104_000
+POPULATION_COMBINE_VRT_NODATA = -1
 GTIFF_CREATION_OPTIONS = (
     "TILED=YES",
     "BIGTIFF=YES",
@@ -2022,7 +2023,7 @@ def combine_pops(
                             "width": target.width,
                             "height": target.height,
                             "resampling": Resampling.nearest,
-                            "nodata": 0,
+                            "nodata": POPULATION_COMBINE_VRT_NODATA,
                         }
                         if source.nodata is not None:
                             vrt_kwargs["src_nodata"] = source.nodata
@@ -2033,6 +2034,7 @@ def combine_pops(
                                     1,
                                     window=window,
                                 ).astype(np.float32, copy=False)
+                                incoming[incoming < 0] = 0
                                 combine_state["pixels"] += int(
                                     window.width * window.height
                                 )


### PR DESCRIPTION
## Summary
- Use a negative virtual nodata sentinel for `WarpedVRT` during population combine instead of `0`.
- Clamp negative VRT fill values back to zero before summing or max-combining population windows.
- Preserve zero-valued source pixels as valid population values.
- Rebased/merged current `main` so this PR includes the latest full-extent AOI mask work and is reviewable again.

Closes #62

## Why this fixes the warning
The warning comes from the final `combine_pops` streaming/stitch step. It was opening each source raster through `WarpedVRT(..., nodata=0)`. Since `0` is a valid value in population rasters, GDAL changed real source zeros to `1.4013e-45` so they would not be confused with destination nodata.

This PR changes the VRT fill nodata to `-1`, which is outside the valid population range, then converts negative VRT fill pixels back to `0` immediately after reading each window.

## Testing
- `python -m py_compile workflow_runner.py tests\test_population_combine_nodata.py`
- `git diff --check origin/main...HEAD`
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m unittest tests.test_population_combine_nodata`
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m unittest discover -s tests`

## Notes
- The `py311` unittest runs emit local `GDAL_DATA` warnings because this shell does not have `GDAL_DATA` set; the tests pass.
- The new regression test verifies that source zero population values stay zero while VRT fill nodata uses the negative sentinel and is clamped back to zero.