### PR TITLE
Fix full-extent travel-time AOI mask

### DIFF
--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1,0 +1,70 @@
+import unittest
+
+import numpy as np
+from pyproj import CRS, Transformer
+from rasterio.transform import from_origin
+from shapely.geometry import Point, box
+from shapely.ops import transform
+
+import workflow_runner
+
+
+class Wgs84BoundsMaskTests(unittest.TestCase):
+
+    def test_bounds_mask_includes_wgs84_pixel_centers(self):
+        mask = workflow_runner._rasterize_wgs84_bounds_mask(
+            (-1.5, -0.5, 1.5, 1.5),
+            from_origin(-2, 2, 1, 1),
+            "EPSG:4326",
+            4,
+            4,
+        )
+        expected = np.array(
+            [
+                [1, 1, 1, 1],
+                [1, 1, 1, 1],
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+            ],
+            dtype=np.int8,
+        )
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_bounds_mask_avoids_projected_full_extent_polygon_collapse(self):
+        target_crs = CRS.from_proj4(
+            "+proj=aeqd +lat_0=12.33225837 +lon_0=-0.0569542 "
+            "+datum=WGS84 +units=m +no_defs"
+        )
+        full_extent_bounds = (-179.113, -54.822, 179.0, 79.487)
+        full_extent_polygon = box(*full_extent_bounds)
+        transformer = Transformer.from_crs(
+            "EPSG:4326", target_crs, always_xy=True
+        )
+        projected_polygon = transform(transformer.transform, full_extent_polygon)
+
+        india_lon_lat = (77.0, 22.0)
+        india_x, india_y = transformer.transform(*india_lon_lat)
+
+        self.assertTrue(
+            full_extent_polygon.covers(Point(*india_lon_lat)),
+            "India sample point should be inside the generated WGS84 AOI.",
+        )
+        self.assertFalse(
+            projected_polygon.covers(Point(india_x, india_y)),
+            "Projecting the near-global AOI rectangle collapses the useful "
+            "rasterized area around the projection center.",
+        )
+
+        india_center_transform = from_origin(india_x - 0.5, india_y + 0.5, 1, 1)
+        mask = workflow_runner._rasterize_wgs84_bounds_mask(
+            full_extent_bounds,
+            india_center_transform,
+            target_crs,
+            1,
+            1,
+        )
+        self.assertEqual(mask[0, 0], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1387,6 +1387,7 @@ def apply_travel_time_mask(
     target_crs: str,
     target_pop_raster_path: Path,
     working_dir: Path,
+    use_wgs84_bounds_mask: bool = False,
 ):
     """
     Create a travel-time mask clipped to an AOI.
@@ -1397,6 +1398,10 @@ def apply_travel_time_mask(
         aoi_vector_path (str | Path): Path to a vector dataset (e.g. Shapefile,
             GeoPackage) defining the area of interest to clip to.
         max_hours (float): Maximum travel time in hours to include.
+        use_wgs84_bounds_mask (bool): If true, rasterize the AOI as a WGS84
+            bounds mask from pixel centers. This is intended for generated
+            full-extent AOIs, where projecting a near-global rectangle into a
+            local projected CRS can collapse the rasterized mask.
 
     Returns:
         rasterio.io.DatasetReader: An in-memory raster mask where pixels within
@@ -1406,6 +1411,7 @@ def apply_travel_time_mask(
     max_time_mins = max_hours * 60
 
     aoi_vector = gpd.read_file(aoi_vector_path)
+    aoi_wgs84_bounds = aoi_vector.to_crs("EPSG:4326").total_bounds
     projected_gdf = aoi_vector.to_crs(target_crs)
     bbox = projected_gdf.total_bounds
     # This max-distance bound is precomputed for the global friction raster
@@ -1448,13 +1454,22 @@ def apply_travel_time_mask(
         reference_meta=ref_meta,
     )
 
-    mask_array = rasterio.features.rasterize(
-        ((geom, 1) for geom in projected_gdf.geometry),
-        out_shape=(ref_meta["height"], ref_meta["width"]),
-        transform=ref_meta["transform"],
-        fill=0,
-        dtype=rasterio.uint8,
-    ).astype(np.int8)
+    if use_wgs84_bounds_mask:
+        mask_array = _rasterize_wgs84_bounds_mask(
+            aoi_wgs84_bounds,
+            ref_meta["transform"],
+            ref_meta["crs"],
+            ref_meta["height"],
+            ref_meta["width"],
+        )
+    else:
+        mask_array = rasterio.features.rasterize(
+            ((geom, 1) for geom in projected_gdf.geometry),
+            out_shape=(ref_meta["height"], ref_meta["width"]),
+            transform=ref_meta["transform"],
+            fill=0,
+            dtype=rasterio.uint8,
+        ).astype(np.int8)
 
     aoi_meta = ref_meta.copy()
     aoi_meta.update(
@@ -1908,6 +1923,45 @@ def _iter_block_windows(window: Window, block_size: int = RASTER_BLOCK_SIZE):
             yield Window(col_off, row_off, block_width, block_height)
 
 
+def _rasterize_wgs84_bounds_mask(
+    bounds_wgs84,
+    target_transform,
+    target_crs,
+    height: int,
+    width: int,
+) -> np.ndarray:
+    """Create a binary mask from WGS84 bounds using target pixel centers.
+
+    This avoids projecting and rasterizing a near-global WGS84 polygon into a
+    local projected CRS, which can collapse the rasterized geometry near the
+    projection seam.
+    """
+    minx, miny, maxx, maxy = bounds_wgs84
+    transformer = Transformer.from_crs(target_crs, "EPSG:4326", always_xy=True)
+    mask_array = np.zeros((height, width), dtype=np.int8)
+    full_window = Window(0, 0, width, height)
+    for window in _iter_block_windows(full_window):
+        row_start = int(window.row_off)
+        row_stop = row_start + int(window.height)
+        col_start = int(window.col_off)
+        col_stop = col_start + int(window.width)
+        rows = np.arange(row_start, row_stop, dtype=np.float64) + 0.5
+        cols = np.arange(col_start, col_stop, dtype=np.float64) + 0.5
+        col_grid, row_grid = np.meshgrid(cols, rows)
+        x_grid, y_grid = target_transform * (col_grid, row_grid)
+        lon_grid, lat_grid = transformer.transform(x_grid, y_grid)
+        valid_lon_lat = np.isfinite(lon_grid) & np.isfinite(lat_grid)
+        if minx <= maxx:
+            inside_lon = (lon_grid >= minx) & (lon_grid <= maxx)
+        else:
+            inside_lon = (lon_grid >= minx) | (lon_grid <= maxx)
+        inside_lat = (lat_grid >= miny) & (lat_grid <= maxy)
+        mask_array[row_start:row_stop, col_start:col_stop] = (
+            valid_lon_lat & inside_lon & inside_lat
+        ).astype(np.int8)
+    return mask_array
+
+
 def _create_zeroed_raster(target_path: Path, profile: dict) -> None:
     """Create a zero-filled raster for later windowed max writes.
 
@@ -2258,6 +2312,10 @@ def main() -> None:
             if mask_section["type"] == "travel_time_population":
                 travel_time_working_dir = working_dir / section_id
                 travel_time_working_dir.mkdir(parents=True, exist_ok=True)
+                use_wgs84_bounds_mask = (
+                    aoi_key == FULL_RASTER_EXTENT_AOI_ID
+                    and debug_drain_index is None
+                )
 
                 travel_task = task_graph.add_task(
                     func=apply_travel_time_mask,
@@ -2269,6 +2327,7 @@ def main() -> None:
                         aoi_info["target_crs"].crs,
                         target_pop_raster_path,
                         travel_time_working_dir,
+                        use_wgs84_bounds_mask,
                     ),
                     store_result=True,
                     target_path_list=[target_pop_raster_path],


### PR DESCRIPTION
## Summary
- Fixes generated full-raster travel-time AOI masking by checking target raster pixel centers against the generated AOI's WGS84 bounds.
- Keeps normal AOI and `debug_drain_index` drain AOIs on the existing projected-vector rasterization path.
- Avoids projecting/rasterizing the near-global WGS84 rectangle into the local travel-time CRS, which was collapsing the mask to a narrow prime-meridian swath.

Closes #66

## Evidence
I checked the existing sub-workspace before changing behavior. The clipped population/friction rasters cover the broad projected raster, but the old projected AOI mask only covers a narrow x-range around the projection center.

Point check against the generated full AOI and the travel-time target CRS:

| Sample | In WGS84 AOI bounds | In old projected AOI polygon |
| --- | --- | --- |
| Prime meridian / Africa `(0, 10)` | yes | yes |
| India `(77, 22)` | yes | no |
| Australia `(135, -25)` | yes | no |
| South America `(-60, -10)` | yes | no |
| US `(-100, 40)` | yes | no |
| SE Asia `(105, 10)` | yes | no |

## Testing
- `python -m py_compile workflow_runner.py tests\test_workflow_runner.py`
- `git diff --check`
- `C:\Users\richp\mambaforge\envs\py311\python.exe -m unittest discover -s tests`

## Notes
- The unittest run imports under `py311` and emits local GDAL data warnings because `GDAL_DATA` is not set in this shell, but the tests pass.
- The regression test recreates the old projected-polygon behavior and verifies it misses an India sample point that is inside the generated WGS84 full extent; it then verifies the new WGS84-bounds mask includes that same projected pixel center.