### PR TITLE
Add standalone raster stitching utility

### DIFF
--- a/tests/test_high_performance_stitch_rasters.py
+++ b/tests/test_high_performance_stitch_rasters.py
@@ -1,0 +1,114 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
+from utils.high_performance_stitch_rasters import (
+    read_raster_list,
+    stitch_rasters,
+)
+
+
+class HighPerformanceStitchRastersTests(unittest.TestCase):
+
+    def _write_raster(self, path, array, left, top, nodata=-1):
+        profile = {
+            "driver": "GTiff",
+            "height": array.shape[0],
+            "width": array.shape[1],
+            "count": 1,
+            "dtype": array.dtype,
+            "crs": "EPSG:4326",
+            "transform": from_origin(left, top, 1, 1),
+            "nodata": nodata,
+        }
+        with rasterio.open(path, "w", **profile) as target:
+            target.write(array, 1)
+
+    def test_stitches_adjacent_rasters_and_skips_nodata(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_a_path = workspace_path / "a.tif"
+            raster_b_path = workspace_path / "b.tif"
+            output_path = workspace_path / "stitched.tif"
+
+            self._write_raster(
+                raster_a_path,
+                np.array([[1, -1], [3, 4]], dtype=np.int16),
+                0,
+                2,
+            )
+            self._write_raster(
+                raster_b_path,
+                np.array([[5, 6], [-1, 8]], dtype=np.int16),
+                2,
+                2,
+            )
+
+            stitch_rasters([raster_a_path, raster_b_path], output_path)
+
+            with rasterio.open(output_path) as stitched:
+                result = stitched.read(1)
+                self.assertEqual(stitched.nodata, -1)
+                self.assertEqual(stitched.width, 4)
+                self.assertEqual(stitched.height, 2)
+
+            np.testing.assert_array_equal(
+                result,
+                np.array([[1, -1, 5, 6], [3, 4, -1, 8]], dtype=np.int16),
+            )
+
+    def test_later_rasters_overwrite_earlier_valid_pixels(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_a_path = workspace_path / "a.tif"
+            raster_b_path = workspace_path / "b.tif"
+            output_path = workspace_path / "stitched.tif"
+
+            self._write_raster(
+                raster_a_path,
+                np.array([[1, 2], [3, 4]], dtype=np.int16),
+                0,
+                2,
+            )
+            self._write_raster(
+                raster_b_path,
+                np.array([[9, -1], [-1, 12]], dtype=np.int16),
+                0,
+                2,
+            )
+
+            stitch_rasters([raster_a_path, raster_b_path], output_path)
+
+            with rasterio.open(output_path) as stitched:
+                result = stitched.read(1)
+
+            np.testing.assert_array_equal(
+                result,
+                np.array([[9, 2], [3, 12]], dtype=np.int16),
+            )
+
+    def test_reads_list_relative_to_list_file(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_path = workspace_path / "a.tif"
+            list_path = workspace_path / "rasters.txt"
+            self._write_raster(
+                raster_path,
+                np.array([[1]], dtype=np.int16),
+                0,
+                1,
+            )
+            list_path.write_text(
+                "\n# comment\n" + raster_path.name + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(read_raster_list(list_path), [raster_path])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -243,7 +243,15 @@ def _iter_block_windows(
 
 
 def _valid_mask(data: np.ndarray, nodata) -> np.ndarray:
-    """Return a mask where ``data`` is not nodata."""
+    """Return a boolean mask for valid raster values.
+
+    Args:
+        data: Raster data array read from a source window.
+        nodata: Nodata value to exclude. ``None`` means every value is valid.
+
+    Returns:
+        Boolean array with ``True`` where ``data`` is not nodata.
+    """
     if nodata is None:
         return np.ones(data.shape, dtype=bool)
     if np.issubdtype(data.dtype, np.floating) and np.isnan(nodata):

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -1,0 +1,330 @@
+"""Stitch rasters listed in a text file into one common output grid.
+
+This script is intentionally standalone: it does not import any project modules
+from this repository. It uses the first input raster as the reference for CRS,
+pixel size, dtype, band count, and nodata. The output extent is the union of all
+input raster bounds, aligned to the first raster's pixel grid.
+
+Example:
+    python utils/high_performance_stitch_rasters.py rasters.txt stitched.tif
+
+The raster list should contain one path per line. Blank lines and lines whose
+first non-whitespace character is ``#`` are ignored. Relative paths are resolved
+relative to the list file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+import numpy as np
+import rasterio
+from rasterio.enums import Resampling
+from rasterio.transform import Affine, from_origin
+from rasterio.vrt import WarpedVRT
+from rasterio.windows import Window, from_bounds
+
+try:
+    from tqdm.auto import tqdm
+except ImportError:  # pragma: no cover - tqdm is expected but not required.
+    tqdm = None
+
+
+DEFAULT_BLOCK_SIZE = 256
+DEFAULT_CREATION_OPTIONS = {
+    "BIGTIFF": "YES",
+    "NUM_THREADS": "ALL_CPUS",
+    "compress": "lzw",
+    "tiled": True,
+    "blockxsize": DEFAULT_BLOCK_SIZE,
+    "blockysize": DEFAULT_BLOCK_SIZE,
+}
+
+
+def _progress(iterable: Iterable, **kwargs) -> Iterable:
+    """Wrap ``iterable`` in tqdm when available."""
+    if tqdm is None:
+        return iterable
+    return tqdm(iterable, **kwargs)
+
+
+def read_raster_list(list_path: Path) -> list[Path]:
+    """Read raster paths from ``list_path``.
+
+    Args:
+        list_path: Text file with one raster path per line. Blank lines and
+            comment lines starting with ``#`` are ignored. Relative raster paths
+            are resolved relative to ``list_path.parent``.
+
+    Returns:
+        Ordered list of raster paths.
+
+    Raises:
+        ValueError: If no raster paths are found.
+        FileNotFoundError: If a listed raster does not exist.
+    """
+    list_path = Path(list_path).resolve()
+    raster_paths: list[Path] = []
+    with list_path.open("r", encoding="utf-8") as path_file:
+        for line_number, raw_line in enumerate(path_file, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            raster_path = Path(line)
+            if not raster_path.is_absolute():
+                raster_path = list_path.parent / raster_path
+            raster_path = raster_path.resolve()
+            if not raster_path.exists():
+                raise FileNotFoundError(
+                    f"Raster listed on line {line_number} does not exist: "
+                    f"{raster_path}"
+                )
+            raster_paths.append(raster_path)
+
+    if not raster_paths:
+        raise ValueError(f"No raster paths were found in {list_path}")
+    return raster_paths
+
+
+def _require_north_up(transform: Affine, raster_path: Path) -> None:
+    """Raise when a raster transform is rotated or south-up."""
+    if not math.isclose(transform.b, 0.0) or not math.isclose(transform.d, 0.0):
+        raise ValueError(f"Rotated rasters are not supported: {raster_path}")
+    if transform.a <= 0 or transform.e >= 0:
+        raise ValueError(
+            "Expected a north-up raster with positive x pixel size and "
+            f"negative y pixel size: {raster_path}"
+        )
+
+
+def _aligned_output_grid(
+    raster_paths: Sequence[Path],
+) -> tuple[dict, tuple[float, float, float, float]]:
+    """Build an output Rasterio profile from input rasters."""
+    with rasterio.open(raster_paths[0]) as reference:
+        _require_north_up(reference.transform, raster_paths[0])
+        reference_crs = reference.crs
+        if reference_crs is None:
+            raise ValueError(f"Reference raster has no CRS: {raster_paths[0]}")
+        reference_transform = reference.transform
+        pixel_width = reference_transform.a
+        pixel_height = abs(reference_transform.e)
+        origin_x = reference_transform.c
+        origin_y = reference_transform.f
+        profile = reference.profile.copy()
+        reference_count = reference.count
+        reference_dtypes = reference.dtypes
+
+    minx = math.inf
+    miny = math.inf
+    maxx = -math.inf
+    maxy = -math.inf
+
+    for raster_path in raster_paths:
+        with rasterio.open(raster_path) as source:
+            _require_north_up(source.transform, raster_path)
+            if source.crs != reference_crs:
+                raise ValueError(
+                    f"CRS mismatch for {raster_path}: expected "
+                    f"{reference_crs}, got {source.crs}"
+                )
+            if source.count != reference_count:
+                raise ValueError(
+                    f"Band-count mismatch for {raster_path}: expected "
+                    f"{reference_count}, got {source.count}"
+                )
+            if source.dtypes != reference_dtypes:
+                raise ValueError(
+                    f"Dtype mismatch for {raster_path}: expected "
+                    f"{reference_dtypes}, got {source.dtypes}"
+                )
+            minx = min(minx, source.bounds.left)
+            miny = min(miny, source.bounds.bottom)
+            maxx = max(maxx, source.bounds.right)
+            maxy = max(maxy, source.bounds.top)
+
+    left = origin_x + math.floor((minx - origin_x) / pixel_width) * pixel_width
+    right = origin_x + math.ceil((maxx - origin_x) / pixel_width) * pixel_width
+    top = origin_y - math.floor((origin_y - maxy) / pixel_height) * pixel_height
+    bottom = origin_y - math.ceil((origin_y - miny) / pixel_height) * pixel_height
+
+    width = int(round((right - left) / pixel_width))
+    height = int(round((top - bottom) / pixel_height))
+    if width <= 0 or height <= 0:
+        raise ValueError(
+            f"Combined raster dimensions are invalid: {width}x{height}"
+        )
+
+    profile.update(
+        {
+            "driver": "GTiff",
+            "width": width,
+            "height": height,
+            "transform": from_origin(left, top, pixel_width, pixel_height),
+        }
+    )
+    profile.update(DEFAULT_CREATION_OPTIONS)
+    return profile, (left, bottom, right, top)
+
+
+def _integer_window(raw_window: Window, width: int, height: int) -> Window:
+    """Round ``raw_window`` outward and clamp it to raster dimensions."""
+    col_start = max(0, math.floor(raw_window.col_off))
+    row_start = max(0, math.floor(raw_window.row_off))
+    col_stop = min(width, math.ceil(raw_window.col_off + raw_window.width))
+    row_stop = min(height, math.ceil(raw_window.row_off + raw_window.height))
+    return Window(
+        col_start,
+        row_start,
+        max(0, col_stop - col_start),
+        max(0, row_stop - row_start),
+    )
+
+
+def _iter_block_windows(
+    window: Window,
+    block_size: int = DEFAULT_BLOCK_SIZE,
+) -> Iterator[Window]:
+    """Yield block-sized windows within ``window``."""
+    row_start = int(window.row_off)
+    col_start = int(window.col_off)
+    row_stop = int(window.row_off + window.height)
+    col_stop = int(window.col_off + window.width)
+    for row_off in range(row_start, row_stop, block_size):
+        block_height = min(block_size, row_stop - row_off)
+        for col_off in range(col_start, col_stop, block_size):
+            block_width = min(block_size, col_stop - col_off)
+            yield Window(col_off, row_off, block_width, block_height)
+
+
+def _valid_mask(data: np.ndarray, nodata) -> np.ndarray:
+    """Return a mask where ``data`` is not nodata."""
+    if nodata is None:
+        return np.ones(data.shape, dtype=bool)
+    if np.issubdtype(data.dtype, np.floating) and np.isnan(nodata):
+        return ~np.isnan(data)
+    return data != nodata
+
+
+def _initialize_output(target: rasterio.DatasetWriter, nodata) -> None:
+    """Fill the output raster with nodata when nodata is defined."""
+    if nodata is None:
+        return
+
+    for _, window in _progress(
+        target.block_windows(1),
+        desc="initialize output",
+        unit="block",
+    ):
+        shape = (target.count, int(window.height), int(window.width))
+        fill_block = np.full(shape, nodata, dtype=target.dtypes[0])
+        target.write(fill_block, window=window)
+
+
+def stitch_rasters(
+    raster_paths: Sequence[Path],
+    output_path: Path,
+) -> Path:
+    """Stitch ``raster_paths`` into ``output_path``.
+
+    Later rasters overwrite earlier rasters wherever the later raster has valid
+    data. Source nodata pixels are skipped.
+    """
+    if not raster_paths:
+        raise ValueError("At least one raster path is required.")
+
+    raster_paths = [Path(path).resolve() for path in raster_paths]
+    output_path = Path(output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    output_profile, _ = _aligned_output_grid(raster_paths)
+    output_nodata = output_profile.get("nodata")
+
+    with rasterio.open(output_path, "w", **output_profile) as output:
+        _initialize_output(output, output_nodata)
+
+    with rasterio.open(output_path, "r+") as output:
+        for raster_path in _progress(
+            raster_paths,
+            desc="stitch rasters",
+            unit="raster",
+        ):
+            with rasterio.open(raster_path) as source:
+                target_window = _integer_window(
+                    from_bounds(*source.bounds, transform=output.transform),
+                    output.width,
+                    output.height,
+                )
+                if target_window.width == 0 or target_window.height == 0:
+                    continue
+
+                vrt_kwargs = {
+                    "crs": output.crs,
+                    "transform": output.transform,
+                    "width": output.width,
+                    "height": output.height,
+                    "resampling": Resampling.nearest,
+                }
+                if output_nodata is not None:
+                    vrt_kwargs["nodata"] = output_nodata
+                if source.nodata is not None:
+                    vrt_kwargs["src_nodata"] = source.nodata
+
+                with WarpedVRT(source, **vrt_kwargs) as source_vrt:
+                    effective_nodata = (
+                        source_vrt.nodata
+                        if source_vrt.nodata is not None
+                        else source.nodata
+                    )
+                    for window in _iter_block_windows(target_window):
+                        data = source_vrt.read(window=window)
+                        valid = _valid_mask(data, effective_nodata)
+                        if not np.any(valid):
+                            continue
+                        if np.all(valid):
+                            output.write(data, window=window)
+                            continue
+                        existing = output.read(window=window)
+                        existing[valid] = data[valid]
+                        output.write(existing, window=window)
+
+    return output_path
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Stitch rasters listed in a text file into a common output grid. "
+            "The first raster defines CRS, pixel size, dtype, band count, and "
+            "nodata. Later rasters overwrite earlier rasters where they have "
+            "valid data."
+        )
+    )
+    parser.add_argument(
+        "raster_list",
+        type=Path,
+        help="Text file with one raster path per line.",
+    )
+    parser.add_argument(
+        "output_raster",
+        type=Path,
+        help="Output GeoTIFF path.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Run the CLI."""
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    raster_paths = read_raster_list(args.raster_list)
+    output_path = stitch_rasters(raster_paths, args.output_raster)
+    print(f"Wrote {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -321,6 +321,9 @@ def stitch_rasters(
             unit="raster",
         ):
             with rasterio.open(raster_path) as source:
+                # Map the source raster's world-coordinate bounds into the
+                # shared output grid so reads/writes stay limited to the part
+                # of the output touched by this source.
                 target_window = _integer_window(
                     from_bounds(*source.bounds, transform=output.transform),
                     output.width,

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -363,7 +363,11 @@ def stitch_rasters(
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    """Build the command-line argument parser."""
+    """Build the command-line argument parser.
+
+    Returns:
+        Configured argument parser for the standalone stitching CLI.
+    """
     parser = argparse.ArgumentParser(
         description=(
             "Stitch rasters listed in a text file into a common output grid. "

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -222,7 +222,15 @@ def _iter_block_windows(
     window: Window,
     block_size: int = DEFAULT_BLOCK_SIZE,
 ) -> Iterator[Window]:
-    """Yield block-sized windows within ``window``."""
+    """Yield fixed-size windows within a larger window.
+
+    Args:
+        window: Parent window to split into smaller processing windows.
+        block_size: Maximum width and height of each yielded window.
+
+    Yields:
+        ``Window`` objects that cover ``window`` without extending beyond it.
+    """
     row_start = int(window.row_off)
     col_start = int(window.col_off)
     row_stop = int(window.row_off + window.height)

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -288,6 +288,18 @@ def stitch_rasters(
 
     Later rasters overwrite earlier rasters wherever the later raster has valid
     data. Source nodata pixels are skipped.
+
+    Args:
+        raster_paths: Ordered raster paths to stitch. The first raster defines
+            the output grid metadata.
+        output_path: GeoTIFF path to create.
+
+    Returns:
+        Resolved output raster path.
+
+    Raises:
+        ValueError: If no raster paths are provided or the rasters are not
+            compatible for stitching.
     """
     if not raster_paths:
         raise ValueError("At least one raster path is required.")

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -112,7 +112,22 @@ def _require_north_up(transform: Affine, raster_path: Path) -> None:
 def _aligned_output_grid(
     raster_paths: Sequence[Path],
 ) -> tuple[dict, tuple[float, float, float, float]]:
-    """Build an output Rasterio profile from input rasters."""
+    """Build an output Rasterio profile from input rasters.
+
+    Args:
+        raster_paths: Ordered input raster paths. The first raster defines the
+            output CRS, pixel size, dtype, band count, nodata, and grid origin.
+
+    Returns:
+        Tuple of ``(profile, bounds)`` where ``profile`` is the Rasterio output
+        profile and ``bounds`` is ``(left, bottom, right, top)`` in the output
+        CRS.
+
+    Raises:
+        ValueError: If the reference raster has no CRS, input rasters have
+            incompatible CRS/band/dtype metadata, any raster is not north-up,
+            or the combined output dimensions are invalid.
+    """
     with rasterio.open(raster_paths[0]) as reference:
         _require_north_up(reference.transform, raster_paths[0])
         reference_crs = reference.crs

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -90,7 +90,16 @@ def read_raster_list(list_path: Path) -> list[Path]:
 
 
 def _require_north_up(transform: Affine, raster_path: Path) -> None:
-    """Raise when a raster transform is rotated or south-up."""
+    """Validate that a raster transform is north-up.
+
+    Args:
+        transform: Raster affine transform to validate.
+        raster_path: Source raster path used in error messages.
+
+    Raises:
+        ValueError: If the transform is rotated, flipped, or otherwise not
+            north-up with positive x pixel size and negative y pixel size.
+    """
     if not math.isclose(transform.b, 0.0) or not math.isclose(transform.d, 0.0):
         raise ValueError(f"Rotated rasters are not supported: {raster_path}")
     if transform.a <= 0 or transform.e >= 0:

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -34,6 +34,7 @@ except ImportError:  # pragma: no cover - tqdm is expected but not required.
 
 
 DEFAULT_BLOCK_SIZE = 256
+DEFAULT_IO_WINDOW_SIZE = DEFAULT_BLOCK_SIZE * 10
 DEFAULT_CREATION_OPTIONS = {
     "BIGTIFF": "YES",
     "NUM_THREADS": "ALL_CPUS",
@@ -350,7 +351,10 @@ def stitch_rasters(
                         if source_vrt.nodata is not None
                         else source.nodata
                     )
-                    for window in _iter_block_windows(target_window):
+                    for window in _iter_block_windows(
+                        target_window,
+                        DEFAULT_IO_WINDOW_SIZE,
+                    ):
                         data = source_vrt.read(window=window)
                         valid = _valid_mask(data, effective_nodata)
                         if not np.any(valid):

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -260,7 +260,13 @@ def _valid_mask(data: np.ndarray, nodata) -> np.ndarray:
 
 
 def _initialize_output(target: rasterio.DatasetWriter, nodata) -> None:
-    """Fill the output raster with nodata when nodata is defined."""
+    """Fill an output raster with nodata when nodata is defined.
+
+    Args:
+        target: Open output raster dataset to initialize.
+        nodata: Nodata value to write into every output band and block. If
+            ``None``, no initialization is performed.
+    """
     if nodata is None:
         return
 

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -195,7 +195,17 @@ def _aligned_output_grid(
 
 
 def _integer_window(raw_window: Window, width: int, height: int) -> Window:
-    """Round ``raw_window`` outward and clamp it to raster dimensions."""
+    """Round a window outward and clamp it to raster dimensions.
+
+    Args:
+        raw_window: Window with possibly fractional offsets or dimensions.
+        width: Raster width in pixels.
+        height: Raster height in pixels.
+
+    Returns:
+        Integer ``Window`` that covers ``raw_window`` and stays within the
+        raster dimensions.
+    """
     col_start = max(0, math.floor(raw_window.col_off))
     row_start = max(0, math.floor(raw_window.row_off))
     col_stop = min(width, math.ceil(raw_window.col_off + raw_window.width))


### PR DESCRIPTION
## Summary
- Adds `utils/high_performance_stitch_rasters.py`, a standalone CLI for stitching rasters listed in a text file into one common GeoTIFF.
- Uses the first raster for CRS, pixel size, dtype, band count, nodata, and grid alignment.
- Computes the combined bounding-box extent, writes tiled 256x256 LZW-compressed output, skips source nodata pixels, and lets later rasters overwrite earlier valid pixels.
- Adds focused tests for adjacent stitching, nodata skipping, overwrite behavior, and relative paths in the raster list.

Closes #70

## Testing
- `mamba run -n py311 python -m unittest tests.test_high_performance_stitch_rasters`
- `mamba run -n py311 python -m unittest discover tests`
- `mamba run -n py311 python -m py_compile utils\high_performance_stitch_rasters.py tests\test_high_performance_stitch_rasters.py`
- `git diff --check`

## Notes
- The final GeoTIFF write is intentionally sequential to avoid concurrent writes to the same output dataset; performance comes from block-window reads/writes, tiled output, and GeoTIFF threading options.