### PR TITLE
Add parallel raster stitch runner

### DIFF
--- a/tests/test_high_performance_stitch_rasters.py
+++ b/tests/test_high_performance_stitch_rasters.py
@@ -69,6 +69,43 @@ class HighPerformanceStitchRastersTests(unittest.TestCase):
                 np.array([[1, 9], [10, 4]], dtype=np.int16),
             )
 
+    def test_reference_nodata_takes_precedence_over_override(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_a_path = workspace_path / "a.tif"
+            raster_b_path = workspace_path / "b.tif"
+            output_path = workspace_path / "stitched.tif"
+
+            self._write_raster(
+                raster_a_path,
+                np.array([[1, 2], [3, 4]], dtype=np.int16),
+                0,
+                2,
+                nodata=-1,
+            )
+            self._write_raster(
+                raster_b_path,
+                np.array([[0, 9], [10, 0]], dtype=np.int16),
+                0,
+                2,
+                nodata=None,
+            )
+
+            stitch_rasters(
+                [raster_a_path, raster_b_path],
+                output_path,
+                nodata_override=0,
+            )
+
+            with rasterio.open(output_path) as stitched:
+                result = stitched.read(1)
+                self.assertEqual(stitched.nodata, -1)
+
+            np.testing.assert_array_equal(
+                result,
+                np.array([[0, 9], [10, 0]], dtype=np.int16),
+            )
+
     def test_stitches_adjacent_rasters_and_skips_nodata(self):
         with tempfile.TemporaryDirectory() as workspace:
             workspace_path = Path(workspace)

--- a/tests/test_high_performance_stitch_rasters.py
+++ b/tests/test_high_performance_stitch_rasters.py
@@ -127,6 +127,34 @@ class HighPerformanceStitchRastersTests(unittest.TestCase):
 
             self.assertEqual(read_raster_list(list_path), [raster_path])
 
+    def test_reports_progress_events_and_compresses_output(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_path = workspace_path / "a.tif"
+            output_path = workspace_path / "stitched.tif"
+            self._write_raster(
+                raster_path,
+                np.array([[1, 2], [3, 4]], dtype=np.int16),
+                0,
+                2,
+            )
+            progress_events = []
+
+            stitch_rasters(
+                [raster_path],
+                output_path,
+                progress_callback=progress_events.append,
+            )
+
+            with rasterio.open(output_path) as stitched:
+                self.assertEqual(stitched.profile["compress"], "lzw")
+
+            event_names = [event["event"] for event in progress_events]
+            self.assertIn("job_start", event_names)
+            self.assertIn("stage_start", event_names)
+            self.assertIn("progress", event_names)
+            self.assertIn("job_done", event_names)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_high_performance_stitch_rasters.py
+++ b/tests/test_high_performance_stitch_rasters.py
@@ -32,6 +32,43 @@ class HighPerformanceStitchRastersTests(unittest.TestCase):
         with rasterio.open(path, "w", **profile) as target:
             target.write(array, 1)
 
+    def test_nodata_override_skips_values_without_source_nodata(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_a_path = workspace_path / "a.tif"
+            raster_b_path = workspace_path / "b.tif"
+            output_path = workspace_path / "stitched.tif"
+
+            self._write_raster(
+                raster_a_path,
+                np.array([[1, 2], [0, 4]], dtype=np.int16),
+                0,
+                2,
+                nodata=None,
+            )
+            self._write_raster(
+                raster_b_path,
+                np.array([[0, 9], [10, 0]], dtype=np.int16),
+                0,
+                2,
+                nodata=None,
+            )
+
+            stitch_rasters(
+                [raster_a_path, raster_b_path],
+                output_path,
+                nodata_override=0,
+            )
+
+            with rasterio.open(output_path) as stitched:
+                result = stitched.read(1)
+                self.assertEqual(stitched.nodata, 0)
+
+            np.testing.assert_array_equal(
+                result,
+                np.array([[1, 9], [10, 4]], dtype=np.int16),
+            )
+
     def test_stitches_adjacent_rasters_and_skips_nodata(self):
         with tempfile.TemporaryDirectory() as workspace:
             workspace_path = Path(workspace)

--- a/tests/test_high_performance_stitch_rasters.py
+++ b/tests/test_high_performance_stitch_rasters.py
@@ -109,6 +109,24 @@ class HighPerformanceStitchRastersTests(unittest.TestCase):
 
             self.assertEqual(read_raster_list(list_path), [raster_path])
 
+    def test_reads_utf16_list_file(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_path = workspace_path / "a.tif"
+            list_path = workspace_path / "rasters.txt"
+            self._write_raster(
+                raster_path,
+                np.array([[1]], dtype=np.int16),
+                0,
+                1,
+            )
+            list_path.write_text(
+                "\n# comment\n" + raster_path.name + "\n",
+                encoding="utf-16",
+            )
+
+            self.assertEqual(read_raster_list(list_path), [raster_path])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_high_performance_stitch_rasters.py
+++ b/tests/test_high_performance_stitch_rasters.py
@@ -7,12 +7,16 @@ import rasterio
 from rasterio.transform import from_origin
 
 from utils.high_performance_stitch_rasters import (
+    DEFAULT_GDAL_CACHEMAX_MB,
     read_raster_list,
     stitch_rasters,
 )
 
 
 class HighPerformanceStitchRastersTests(unittest.TestCase):
+
+    def test_uses_bounded_default_gdal_cache(self):
+        self.assertEqual(DEFAULT_GDAL_CACHEMAX_MB, 256)
 
     def _write_raster(self, path, array, left, top, nodata=-1):
         profile = {

--- a/tests/test_run_parallel_stitch_rasters.py
+++ b/tests/test_run_parallel_stitch_rasters.py
@@ -1,0 +1,54 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from utils.run_parallel_stitch_rasters import (
+    build_stitch_jobs,
+    expand_raster_list_args,
+)
+
+
+class RunParallelStitchRastersTests(unittest.TestCase):
+
+    def test_expands_globs_and_preserves_order(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            first_path = workspace_path / "a.txt"
+            second_path = workspace_path / "b.txt"
+            first_path.write_text("a.tif\n", encoding="utf-8")
+            second_path.write_text("b.tif\n", encoding="utf-8")
+
+            result = expand_raster_list_args(
+                [str(first_path), str(workspace_path / "*.txt")]
+            )
+
+            self.assertEqual(result, [first_path.resolve(), second_path.resolve()])
+
+    def test_builds_default_output_paths_next_to_inputs(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            raster_list_path = Path(workspace) / "example.txt"
+
+            jobs = build_stitch_jobs([raster_list_path], None, "")
+
+            self.assertEqual(jobs[0].raster_list_path, raster_list_path.resolve())
+            self.assertEqual(
+                jobs[0].output_raster_path,
+                raster_list_path.with_suffix(".tif").resolve(),
+            )
+
+    def test_builds_output_paths_in_output_dir_with_suffix(self):
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_list_path = workspace_path / "example.txt"
+            output_dir = workspace_path / "stitched"
+
+            jobs = build_stitch_jobs([raster_list_path], output_dir, "_stitched")
+
+            self.assertEqual(
+                jobs[0].output_raster_path,
+                (output_dir / "example_stitched.tif").resolve(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_parallel_stitch_rasters.py
+++ b/tests/test_run_parallel_stitch_rasters.py
@@ -3,6 +3,8 @@ import unittest
 from pathlib import Path
 
 from utils.run_parallel_stitch_rasters import (
+    StitchJob,
+    _build_stitch_command,
     build_stitch_jobs,
     expand_raster_list_args,
 )
@@ -48,6 +50,21 @@ class RunParallelStitchRastersTests(unittest.TestCase):
                 jobs[0].output_raster_path,
                 (output_dir / "example_stitched.tif").resolve(),
             )
+
+    def test_build_stitch_command_passes_nodata_override(self):
+        job = StitchJob(
+            raster_list_path=Path("rasters.txt"),
+            output_raster_path=Path("stitched.tif"),
+        )
+
+        command = _build_stitch_command(
+            job,
+            Path("stitcher.py"),
+            "python",
+            nodata="0",
+        )
+
+        self.assertEqual(command[-2:], ["--nodata", "0"])
 
 
 if __name__ == "__main__":

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -18,10 +18,15 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 from pathlib import Path
 from typing import Callable, Iterable, Iterator, Sequence
 
 import numpy as np
+
+DEFAULT_GDAL_CACHEMAX_MB = 256
+os.environ.setdefault("GDAL_CACHEMAX", str(DEFAULT_GDAL_CACHEMAX_MB))
+
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.transform import Affine, from_origin

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -16,9 +16,10 @@ relative to the list file. UTF-8 and UTF-16 text files are supported.
 from __future__ import annotations
 
 import argparse
+import json
 import math
 from pathlib import Path
-from typing import Iterable, Iterator, Sequence
+from typing import Callable, Iterable, Iterator, Sequence
 
 import numpy as np
 import rasterio
@@ -35,6 +36,7 @@ except ImportError:  # pragma: no cover - tqdm is expected but not required.
 
 DEFAULT_BLOCK_SIZE = 256
 DEFAULT_IO_WINDOW_SIZE = DEFAULT_BLOCK_SIZE * 10
+PROGRESS_EVENT_PREFIX = "STITCH_PROGRESS "
 DEFAULT_CREATION_OPTIONS = {
     "BIGTIFF": "YES",
     "NUM_THREADS": "ALL_CPUS",
@@ -44,6 +46,7 @@ DEFAULT_CREATION_OPTIONS = {
     "blockysize": DEFAULT_BLOCK_SIZE,
 }
 RASTER_LIST_ENCODINGS = ("utf-8-sig", "utf-16")
+ProgressCallback = Callable[[dict], None]
 
 
 def _progress(iterable: Iterable, **kwargs) -> Iterable:
@@ -51,6 +54,25 @@ def _progress(iterable: Iterable, **kwargs) -> Iterable:
     if tqdm is None:
         return iterable
     return tqdm(iterable, **kwargs)
+
+
+def _emit_progress_event(event: dict) -> None:
+    """Write one machine-readable progress event for parent runners."""
+    print(
+        PROGRESS_EVENT_PREFIX + json.dumps(event, sort_keys=True),
+        flush=True,
+    )
+
+
+def _report_progress(
+    progress_callback: ProgressCallback | None,
+    event: str,
+    **payload,
+) -> None:
+    """Send a progress event when a callback is configured."""
+    if progress_callback is None:
+        return
+    progress_callback({"event": event, **payload})
 
 
 def read_raster_list(list_path: Path) -> list[Path]:
@@ -126,6 +148,7 @@ def _require_north_up(transform: Affine, raster_path: Path) -> None:
 
 def _aligned_output_grid(
     raster_paths: Sequence[Path],
+    progress_callback: ProgressCallback | None = None,
 ) -> tuple[dict, tuple[float, float, float, float]]:
     """Build an output Rasterio profile from input rasters.
 
@@ -162,6 +185,13 @@ def _aligned_output_grid(
     maxx = -math.inf
     maxy = -math.inf
 
+    _report_progress(
+        progress_callback,
+        "stage_start",
+        stage="scan raster metadata",
+        total=len(raster_paths),
+        unit="raster",
+    )
     for raster_path in raster_paths:
         with rasterio.open(raster_path) as source:
             _require_north_up(source.transform, raster_path)
@@ -184,6 +214,8 @@ def _aligned_output_grid(
             miny = min(miny, source.bounds.bottom)
             maxx = max(maxx, source.bounds.right)
             maxy = max(maxy, source.bounds.top)
+        _report_progress(progress_callback, "progress", advance=1)
+    _report_progress(progress_callback, "stage_done")
 
     left = origin_x + math.floor((minx - origin_x) / pixel_width) * pixel_width
     right = origin_x + math.ceil((maxx - origin_x) / pixel_width) * pixel_width
@@ -257,6 +289,18 @@ def _iter_block_windows(
             yield Window(col_off, row_off, block_width, block_height)
 
 
+def _block_window_count(
+    window: Window,
+    block_size: int = DEFAULT_BLOCK_SIZE,
+) -> int:
+    """Return the number of block windows needed to cover ``window``."""
+    if window.width == 0 or window.height == 0:
+        return 0
+    return math.ceil(window.height / block_size) * math.ceil(
+        window.width / block_size
+    )
+
+
 def _valid_mask(data: np.ndarray, nodata) -> np.ndarray:
     """Return a boolean mask for valid raster values.
 
@@ -274,7 +318,11 @@ def _valid_mask(data: np.ndarray, nodata) -> np.ndarray:
     return data != nodata
 
 
-def _initialize_output(target: rasterio.DatasetWriter, nodata) -> None:
+def _initialize_output(
+    target: rasterio.DatasetWriter,
+    nodata,
+    progress_callback: ProgressCallback | None = None,
+) -> None:
     """Fill an output raster with nodata when nodata is defined.
 
     Args:
@@ -282,22 +330,41 @@ def _initialize_output(target: rasterio.DatasetWriter, nodata) -> None:
         nodata: Nodata value to write into every output band and block. If
             ``None``, no initialization is performed.
     """
+    stage = "initialize output"
     if nodata is None:
+        _report_progress(
+            progress_callback,
+            "stage_start",
+            stage=stage,
+            total=0,
+            unit="block",
+        )
+        _report_progress(progress_callback, "stage_done")
         return
 
-    for _, window in _progress(
-        target.block_windows(1),
-        desc="initialize output",
+    block_count = sum(1 for _ in target.block_windows(1))
+    _report_progress(
+        progress_callback,
+        "stage_start",
+        stage=stage,
+        total=block_count,
         unit="block",
-    ):
+    )
+    block_windows = target.block_windows(1)
+    if progress_callback is None:
+        block_windows = _progress(block_windows, desc=stage, unit="block")
+    for _, window in block_windows:
         shape = (target.count, int(window.height), int(window.width))
         fill_block = np.full(shape, nodata, dtype=target.dtypes[0])
         target.write(fill_block, window=window)
+        _report_progress(progress_callback, "progress", advance=1)
+    _report_progress(progress_callback, "stage_done")
 
 
 def stitch_rasters(
     raster_paths: Sequence[Path],
     output_path: Path,
+    progress_callback: ProgressCallback | None = None,
 ) -> Path:
     """Stitch ``raster_paths`` into ``output_path``.
 
@@ -323,18 +390,28 @@ def stitch_rasters(
     output_path = Path(output_path).resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    output_profile, _ = _aligned_output_grid(raster_paths)
+    _report_progress(
+        progress_callback,
+        "job_start",
+        total_sources=len(raster_paths),
+        output_path=str(output_path),
+    )
+    output_profile, _ = _aligned_output_grid(raster_paths, progress_callback)
     output_nodata = output_profile.get("nodata")
 
     with rasterio.open(output_path, "w", **output_profile) as output:
-        _initialize_output(output, output_nodata)
+        _initialize_output(output, output_nodata, progress_callback)
 
     with rasterio.open(output_path, "r+") as output:
-        for raster_path in _progress(
-            raster_paths,
-            desc="stitch rasters",
-            unit="raster",
-        ):
+        raster_iterable = enumerate(raster_paths, start=1)
+        if progress_callback is None:
+            raster_iterable = _progress(
+                raster_iterable,
+                desc="stitch rasters",
+                total=len(raster_paths),
+                unit="raster",
+            )
+        for raster_index, raster_path in raster_iterable:
             with rasterio.open(raster_path) as source:
                 # Map the source raster's world-coordinate bounds into the
                 # shared output grid so reads/writes stay limited to the part
@@ -345,7 +422,32 @@ def stitch_rasters(
                     output.height,
                 )
                 if target_window.width == 0 or target_window.height == 0:
+                    _report_progress(
+                        progress_callback,
+                        "stage_start",
+                        stage=(
+                            f"stitch {raster_index}/{len(raster_paths)}: "
+                            f"{raster_path.name}"
+                        ),
+                        total=0,
+                        unit="block",
+                    )
+                    _report_progress(progress_callback, "stage_done")
                     continue
+                block_count = _block_window_count(
+                    target_window,
+                    DEFAULT_IO_WINDOW_SIZE,
+                )
+                _report_progress(
+                    progress_callback,
+                    "stage_start",
+                    stage=(
+                        f"stitch {raster_index}/{len(raster_paths)}: "
+                        f"{raster_path.name}"
+                    ),
+                    total=block_count,
+                    unit="block",
+                )
 
                 vrt_kwargs = {
                     "crs": output.crs,
@@ -372,14 +474,27 @@ def stitch_rasters(
                         data = source_vrt.read(window=window)
                         valid = _valid_mask(data, effective_nodata)
                         if not np.any(valid):
+                            _report_progress(
+                                progress_callback,
+                                "progress",
+                                advance=1,
+                            )
                             continue
                         if np.all(valid):
                             output.write(data, window=window)
+                            _report_progress(
+                                progress_callback,
+                                "progress",
+                                advance=1,
+                            )
                             continue
                         existing = output.read(window=window)
                         existing[valid] = data[valid]
                         output.write(existing, window=window)
+                        _report_progress(progress_callback, "progress", advance=1)
+                _report_progress(progress_callback, "stage_done")
 
+    _report_progress(progress_callback, "job_done", output_path=str(output_path))
     return output_path
 
 
@@ -407,6 +522,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Output GeoTIFF path.",
     )
+    parser.add_argument(
+        "--progress-json",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     return parser
 
 
@@ -415,8 +535,14 @@ def main() -> None:
     parser = build_arg_parser()
     args = parser.parse_args()
     raster_paths = read_raster_list(args.raster_list)
-    output_path = stitch_rasters(raster_paths, args.output_raster)
-    print(f"Wrote {output_path}")
+    progress_callback = _emit_progress_event if args.progress_json else None
+    output_path = stitch_rasters(
+        raster_paths,
+        args.output_raster,
+        progress_callback=progress_callback,
+    )
+    if not args.progress_json:
+        print(f"Wrote {output_path}")
 
 
 if __name__ == "__main__":

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -80,6 +80,19 @@ def _report_progress(
     progress_callback({"event": event, **payload})
 
 
+def _parse_nodata_value(value: str):
+    """Parse a CLI nodata value as int where possible, otherwise float."""
+    lowered_value = value.lower()
+    if any(char in lowered_value for char in ".e") or lowered_value in {
+        "nan",
+        "inf",
+        "+inf",
+        "-inf",
+    }:
+        return float(value)
+    return int(value)
+
+
 def read_raster_list(list_path: Path) -> list[Path]:
     """Read raster paths from ``list_path``.
 
@@ -154,6 +167,7 @@ def _require_north_up(transform: Affine, raster_path: Path) -> None:
 def _aligned_output_grid(
     raster_paths: Sequence[Path],
     progress_callback: ProgressCallback | None = None,
+    nodata_override=None,
 ) -> tuple[dict, tuple[float, float, float, float]]:
     """Build an output Rasterio profile from input rasters.
 
@@ -242,6 +256,8 @@ def _aligned_output_grid(
             "transform": from_origin(left, top, pixel_width, pixel_height),
         }
     )
+    if nodata_override is not None:
+        profile["nodata"] = nodata_override
     profile.update(DEFAULT_CREATION_OPTIONS)
     return profile, (left, bottom, right, top)
 
@@ -370,6 +386,7 @@ def stitch_rasters(
     raster_paths: Sequence[Path],
     output_path: Path,
     progress_callback: ProgressCallback | None = None,
+    nodata_override=None,
 ) -> Path:
     """Stitch ``raster_paths`` into ``output_path``.
 
@@ -380,6 +397,8 @@ def stitch_rasters(
         raster_paths: Ordered raster paths to stitch. The first raster defines
             the output grid metadata.
         output_path: GeoTIFF path to create.
+        nodata_override: Optional nodata value to set on the output raster and
+            treat as nodata in every input raster.
 
     Returns:
         Resolved output raster path.
@@ -401,7 +420,11 @@ def stitch_rasters(
         total_sources=len(raster_paths),
         output_path=str(output_path),
     )
-    output_profile, _ = _aligned_output_grid(raster_paths, progress_callback)
+    output_profile, _ = _aligned_output_grid(
+        raster_paths,
+        progress_callback,
+        nodata_override,
+    )
     output_nodata = output_profile.get("nodata")
 
     with rasterio.open(output_path, "w", **output_profile) as output:
@@ -463,14 +486,19 @@ def stitch_rasters(
                 }
                 if output_nodata is not None:
                     vrt_kwargs["nodata"] = output_nodata
-                if source.nodata is not None:
-                    vrt_kwargs["src_nodata"] = source.nodata
+                source_nodata = (
+                    nodata_override
+                    if nodata_override is not None
+                    else source.nodata
+                )
+                if source_nodata is not None:
+                    vrt_kwargs["src_nodata"] = source_nodata
 
                 with WarpedVRT(source, **vrt_kwargs) as source_vrt:
                     effective_nodata = (
                         source_vrt.nodata
                         if source_vrt.nodata is not None
-                        else source.nodata
+                        else source_nodata
                     )
                     for window in _iter_block_windows(
                         target_window,
@@ -528,6 +556,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Output GeoTIFF path.",
     )
     parser.add_argument(
+        "--nodata",
+        type=_parse_nodata_value,
+        default=None,
+        help=(
+            "Override nodata for the stitched output and ignore this value "
+            "in every input raster."
+        ),
+    )
+    parser.add_argument(
         "--progress-json",
         action="store_true",
         help=argparse.SUPPRESS,
@@ -545,6 +582,7 @@ def main() -> None:
         raster_paths,
         args.output_raster,
         progress_callback=progress_callback,
+        nodata_override=args.nodata,
     )
     if not args.progress_json:
         print(f"Wrote {output_path}")

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -10,7 +10,7 @@ Example:
 
 The raster list should contain one path per line. Blank lines and lines whose
 first non-whitespace character is ``#`` are ignored. Relative paths are resolved
-relative to the list file.
+relative to the list file. UTF-8 and UTF-16 text files are supported.
 """
 
 from __future__ import annotations
@@ -43,6 +43,7 @@ DEFAULT_CREATION_OPTIONS = {
     "blockxsize": DEFAULT_BLOCK_SIZE,
     "blockysize": DEFAULT_BLOCK_SIZE,
 }
+RASTER_LIST_ENCODINGS = ("utf-8-sig", "utf-16")
 
 
 def _progress(iterable: Iterable, **kwargs) -> Iterable:
@@ -65,25 +66,38 @@ def read_raster_list(list_path: Path) -> list[Path]:
 
     Raises:
         ValueError: If no raster paths are found.
+        UnicodeError: If the raster list is not a supported text encoding.
         FileNotFoundError: If a listed raster does not exist.
     """
     list_path = Path(list_path).resolve()
     raster_paths: list[Path] = []
-    with list_path.open("r", encoding="utf-8") as path_file:
-        for line_number, raw_line in enumerate(path_file, start=1):
-            line = raw_line.strip()
-            if not line or line.startswith("#"):
-                continue
-            raster_path = Path(line)
-            if not raster_path.is_absolute():
-                raster_path = list_path.parent / raster_path
-            raster_path = raster_path.resolve()
-            if not raster_path.exists():
-                raise FileNotFoundError(
-                    f"Raster listed on line {line_number} does not exist: "
-                    f"{raster_path}"
-                )
-            raster_paths.append(raster_path)
+    last_decode_error = None
+    for encoding in RASTER_LIST_ENCODINGS:
+        try:
+            lines = list_path.read_text(encoding=encoding).splitlines()
+            break
+        except UnicodeError as error:
+            last_decode_error = error
+    else:
+        raise UnicodeError(
+            f"Could not decode raster list as any supported encoding "
+            f"{RASTER_LIST_ENCODINGS}: {list_path}"
+        ) from last_decode_error
+
+    for line_number, raw_line in enumerate(lines, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        raster_path = Path(line)
+        if not raster_path.is_absolute():
+            raster_path = list_path.parent / raster_path
+        raster_path = raster_path.resolve()
+        if not raster_path.exists():
+            raise FileNotFoundError(
+                f"Raster listed on line {line_number} does not exist: "
+                f"{raster_path}"
+            )
+        raster_paths.append(raster_path)
 
     if not raster_paths:
         raise ValueError(f"No raster paths were found in {list_path}")

--- a/utils/high_performance_stitch_rasters.py
+++ b/utils/high_performance_stitch_rasters.py
@@ -256,7 +256,7 @@ def _aligned_output_grid(
             "transform": from_origin(left, top, pixel_width, pixel_height),
         }
     )
-    if nodata_override is not None:
+    if profile.get("nodata") is None and nodata_override is not None:
         profile["nodata"] = nodata_override
     profile.update(DEFAULT_CREATION_OPTIONS)
     return profile, (left, bottom, right, top)
@@ -397,8 +397,9 @@ def stitch_rasters(
         raster_paths: Ordered raster paths to stitch. The first raster defines
             the output grid metadata.
         output_path: GeoTIFF path to create.
-        nodata_override: Optional nodata value to set on the output raster and
-            treat as nodata in every input raster.
+        nodata_override: Optional nodata value to use when the first raster has
+            no nodata metadata. When applied, this value is also treated as
+            nodata in every input raster.
 
     Returns:
         Resolved output raster path.
@@ -414,6 +415,12 @@ def stitch_rasters(
     output_path = Path(output_path).resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
+    with rasterio.open(raster_paths[0]) as reference:
+        reference_nodata = reference.nodata
+    effective_nodata_override = (
+        nodata_override if reference_nodata is None else None
+    )
+
     _report_progress(
         progress_callback,
         "job_start",
@@ -423,7 +430,7 @@ def stitch_rasters(
     output_profile, _ = _aligned_output_grid(
         raster_paths,
         progress_callback,
-        nodata_override,
+        effective_nodata_override,
     )
     output_nodata = output_profile.get("nodata")
 
@@ -487,8 +494,8 @@ def stitch_rasters(
                 if output_nodata is not None:
                     vrt_kwargs["nodata"] = output_nodata
                 source_nodata = (
-                    nodata_override
-                    if nodata_override is not None
+                    effective_nodata_override
+                    if effective_nodata_override is not None
                     else source.nodata
                 )
                 if source_nodata is not None:
@@ -560,8 +567,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=_parse_nodata_value,
         default=None,
         help=(
-            "Override nodata for the stitched output and ignore this value "
-            "in every input raster."
+            "Use this nodata value when the first raster does not define one, "
+            "and ignore this value in every input raster."
         ),
     )
     parser.add_argument(

--- a/utils/run_parallel_stitch_rasters.py
+++ b/utils/run_parallel_stitch_rasters.py
@@ -14,8 +14,10 @@ import argparse
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 import glob
+import json
 import os
 from pathlib import Path
+import queue
 import subprocess
 import sys
 import time
@@ -23,6 +25,12 @@ from typing import Sequence
 
 
 DEFAULT_STATUS_INTERVAL_SECONDS = 30
+PROGRESS_EVENT_PREFIX = "STITCH_PROGRESS "
+
+try:
+    from tqdm.auto import tqdm
+except ImportError:  # pragma: no cover - tqdm is expected but not required.
+    tqdm = None
 
 
 @dataclass(frozen=True)
@@ -133,6 +141,7 @@ def run_stitch_job(
     job: StitchJob,
     stitcher_script_path: Path,
     python_executable: str,
+    progress_position: int | None = None,
 ) -> StitchResult:
     """Run one stitch job as a child Python process.
 
@@ -140,29 +149,91 @@ def run_stitch_job(
         job: Stitch job to execute.
         stitcher_script_path: Path to ``high_performance_stitch_rasters.py``.
         python_executable: Python executable used to launch the stitcher.
+        progress_position: Optional tqdm line position for this job's live
+            progress bar.
 
     Returns:
         ``StitchResult`` with captured output and runtime.
     """
     start_time = time.monotonic()
-    completed_process = subprocess.run(
+    process = subprocess.Popen(
         [
             python_executable,
             os.fspath(stitcher_script_path),
             os.fspath(job.raster_list_path),
             os.fspath(job.output_raster_path),
+            "--progress-json",
         ],
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         text=True,
-        check=False,
+        bufsize=1,
     )
+    output_lines = []
+    progress_bar = None
+    if tqdm is not None and progress_position is not None:
+        progress_bar = tqdm(
+            total=0,
+            desc=f"{job.raster_list_path.stem}: starting",
+            unit="step",
+            position=progress_position,
+            leave=False,
+            dynamic_ncols=True,
+        )
+    assert process.stdout is not None
+    try:
+        for raw_line in process.stdout:
+            line = raw_line.rstrip()
+            if not line:
+                continue
+            if line.startswith(PROGRESS_EVENT_PREFIX):
+                event = json.loads(line[len(PROGRESS_EVENT_PREFIX) :])
+                if progress_bar is not None:
+                    _update_job_progress_bar(progress_bar, job, event)
+                continue
+            output_lines.append(line)
+    finally:
+        if progress_bar is not None:
+            progress_bar.close()
+
+    returncode = process.wait()
     return StitchResult(
         job=job,
-        returncode=completed_process.returncode,
-        stdout=completed_process.stdout,
-        stderr=completed_process.stderr,
+        returncode=returncode,
+        stdout="\n".join(output_lines),
+        stderr="",
         elapsed_seconds=time.monotonic() - start_time,
     )
+
+
+def _short_progress_text(text: str, max_length: int = 34) -> str:
+    """Return a compact label for a tqdm progress row."""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 1] + "..."
+
+
+def _update_job_progress_bar(
+    progress_bar,
+    job: StitchJob,
+    event: dict,
+) -> None:
+    """Apply one child-process progress event to a job progress bar."""
+    event_type = event.get("event")
+    if event_type == "stage_start":
+        stage = _short_progress_text(event["stage"])
+        progress_bar.reset(total=event.get("total", 0))
+        progress_bar.n = 0
+        progress_bar.unit = event.get("unit", "item")
+        progress_bar.set_description(
+            f"{_short_progress_text(job.raster_list_path.stem, 24)}: {stage}"
+        )
+        progress_bar.refresh()
+    elif event_type == "progress":
+        progress_bar.update(event.get("advance", 1))
+    elif event_type == "stage_done":
+        if progress_bar.total is not None and progress_bar.n < progress_bar.total:
+            progress_bar.update(progress_bar.total - progress_bar.n)
 
 
 def run_stitch_jobs(
@@ -193,56 +264,95 @@ def run_stitch_jobs(
 
     results: list[StitchResult] = []
     futures_to_jobs = {}
+    positions = queue.Queue()
+    for position in range(1, min(workers, len(jobs)) + 1):
+        positions.put(position)
     start_time = time.monotonic()
     last_status_time = start_time
+    overall_progress_bar = None
+    if tqdm is not None:
+        overall_progress_bar = tqdm(
+            total=len(jobs),
+            desc="stitch jobs",
+            unit="job",
+            position=0,
+            dynamic_ncols=True,
+        )
 
-    with ThreadPoolExecutor(max_workers=workers) as executor:
-        for job in jobs:
-            future = executor.submit(
-                run_stitch_job,
+    def run_job_with_progress_position(job: StitchJob) -> StitchResult:
+        position = positions.get()
+        try:
+            return run_stitch_job(
                 job,
                 stitcher_script_path,
                 python_executable,
+                progress_position=position,
             )
-            futures_to_jobs[future] = job
+        finally:
+            positions.put(position)
 
-        pending_futures = set(futures_to_jobs)
-        while pending_futures:
-            done_futures, pending_futures = wait(
-                pending_futures,
-                timeout=1,
-                return_when=FIRST_COMPLETED,
-            )
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            for job in jobs:
+                future = executor.submit(run_job_with_progress_position, job)
+                futures_to_jobs[future] = job
 
-            for future in done_futures:
-                result = future.result()
-                results.append(result)
-                status = "ok" if result.returncode == 0 else "failed"
-                print(
-                    f"[{len(results)}/{len(jobs)}] {status}: "
-                    f"{result.job.raster_list_path.name} "
-                    f"({result.elapsed_seconds:.1f}s)"
+            pending_futures = set(futures_to_jobs)
+            while pending_futures:
+                done_futures, pending_futures = wait(
+                    pending_futures,
+                    timeout=1,
+                    return_when=FIRST_COMPLETED,
                 )
-                if result.stdout:
-                    print(result.stdout.rstrip())
-                if result.stderr:
-                    print(result.stderr.rstrip(), file=sys.stderr)
 
-            now = time.monotonic()
-            if (
-                pending_futures
-                and status_interval_seconds > 0
-                and now - last_status_time >= status_interval_seconds
-            ):
-                running_names = [
-                    futures_to_jobs[future].raster_list_path.name
-                    for future in pending_futures
-                ]
-                print(
-                    f"still running {len(pending_futures)} job(s) after "
-                    f"{now - start_time:.0f}s: {', '.join(running_names)}"
-                )
-                last_status_time = now
+                for future in done_futures:
+                    result = future.result()
+                    results.append(result)
+                    if overall_progress_bar is not None:
+                        overall_progress_bar.update(1)
+                    status = "ok" if result.returncode == 0 else "failed"
+                    status_message = (
+                        f"[{len(results)}/{len(jobs)}] {status}: "
+                        f"{result.job.raster_list_path.name} "
+                        f"({result.elapsed_seconds:.1f}s)"
+                    )
+                    if tqdm is not None:
+                        tqdm.write(status_message)
+                    else:
+                        print(status_message)
+                    if result.stdout:
+                        if tqdm is not None:
+                            tqdm.write(result.stdout.rstrip())
+                        else:
+                            print(result.stdout.rstrip())
+                    if result.stderr:
+                        if tqdm is not None:
+                            tqdm.write(result.stderr.rstrip(), file=sys.stderr)
+                        else:
+                            print(result.stderr.rstrip(), file=sys.stderr)
+
+                now = time.monotonic()
+                if (
+                    pending_futures
+                    and status_interval_seconds > 0
+                    and now - last_status_time >= status_interval_seconds
+                ):
+                    running_names = [
+                        futures_to_jobs[future].raster_list_path.name
+                        for future in pending_futures
+                    ]
+                    status_message = (
+                        f"still running {len(pending_futures)} job(s) after "
+                        f"{now - start_time:.0f}s: {', '.join(running_names)}"
+                    )
+                    if tqdm is not None:
+                        tqdm.write(status_message)
+                    else:
+                        print(status_message)
+                    last_status_time = now
+    finally:
+        if overall_progress_bar is not None:
+            overall_progress_bar.close()
 
     return results
 

--- a/utils/run_parallel_stitch_rasters.py
+++ b/utils/run_parallel_stitch_rasters.py
@@ -137,11 +137,31 @@ def build_stitch_jobs(
     return jobs
 
 
+def _build_stitch_command(
+    job: StitchJob,
+    stitcher_script_path: Path,
+    python_executable: str,
+    nodata: str | None = None,
+) -> list[str]:
+    """Build the subprocess command for one stitch job."""
+    command = [
+        python_executable,
+        os.fspath(stitcher_script_path),
+        os.fspath(job.raster_list_path),
+        os.fspath(job.output_raster_path),
+        "--progress-json",
+    ]
+    if nodata is not None:
+        command.extend(["--nodata", nodata])
+    return command
+
+
 def run_stitch_job(
     job: StitchJob,
     stitcher_script_path: Path,
     python_executable: str,
     progress_position: int | None = None,
+    nodata: str | None = None,
 ) -> StitchResult:
     """Run one stitch job as a child Python process.
 
@@ -151,19 +171,19 @@ def run_stitch_job(
         python_executable: Python executable used to launch the stitcher.
         progress_position: Optional tqdm line position for this job's live
             progress bar.
+        nodata: Optional nodata override to pass to the stitcher.
 
     Returns:
         ``StitchResult`` with captured output and runtime.
     """
     start_time = time.monotonic()
     process = subprocess.Popen(
-        [
+        _build_stitch_command(
+            job,
+            stitcher_script_path,
             python_executable,
-            os.fspath(stitcher_script_path),
-            os.fspath(job.raster_list_path),
-            os.fspath(job.output_raster_path),
-            "--progress-json",
-        ],
+            nodata,
+        ),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
@@ -242,6 +262,7 @@ def run_stitch_jobs(
     stitcher_script_path: Path,
     python_executable: str,
     status_interval_seconds: int = DEFAULT_STATUS_INTERVAL_SECONDS,
+    nodata: str | None = None,
 ) -> list[StitchResult]:
     """Run stitch jobs in parallel with a worker limit.
 
@@ -252,6 +273,7 @@ def run_stitch_jobs(
         python_executable: Python executable used to launch each job.
         status_interval_seconds: Seconds between status messages while jobs
             are still running.
+        nodata: Optional nodata override to pass to each stitch job.
 
     Returns:
         Ordered list of completed ``StitchResult`` objects in completion order.
@@ -287,6 +309,7 @@ def run_stitch_jobs(
                 stitcher_script_path,
                 python_executable,
                 progress_position=position,
+                nodata=nodata,
             )
         finally:
             positions.put(position)
@@ -417,6 +440,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=DEFAULT_STATUS_INTERVAL_SECONDS,
         help="Seconds between running-job status messages. Use 0 to disable.",
     )
+    parser.add_argument(
+        "--nodata",
+        default=None,
+        help=(
+            "Override nodata for each stitched output and ignore this value "
+            "in every input raster."
+        ),
+    )
     return parser
 
 
@@ -439,6 +470,7 @@ def main() -> None:
         args.stitcher_script.resolve(),
         args.python,
         args.status_interval,
+        args.nodata,
     )
     failed_results = [result for result in results if result.returncode != 0]
     if failed_results:

--- a/utils/run_parallel_stitch_rasters.py
+++ b/utils/run_parallel_stitch_rasters.py
@@ -1,0 +1,343 @@
+"""Run multiple raster stitching jobs with a fixed worker limit.
+
+This script launches ``high_performance_stitch_rasters.py`` as child Python
+processes. Each input ``.txt`` file is treated as one stitch job, and the
+default output path is the same path with ``.tif`` as the suffix.
+
+Example:
+    python utils/run_parallel_stitch_rasters.py --workers 12 "D:\\frontiers_data\\countries\\*.txt"
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+import glob
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Sequence
+
+
+DEFAULT_STATUS_INTERVAL_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class StitchJob:
+    """Describe one stitcher subprocess invocation.
+
+    Args:
+        raster_list_path: Path to the text file listing rasters to stitch.
+        output_raster_path: Path where the stitched GeoTIFF should be written.
+    """
+
+    raster_list_path: Path
+    output_raster_path: Path
+
+
+@dataclass(frozen=True)
+class StitchResult:
+    """Describe the outcome of one stitcher subprocess.
+
+    Args:
+        job: Stitch job that was executed.
+        returncode: Subprocess return code.
+        stdout: Captured standard output.
+        stderr: Captured standard error.
+        elapsed_seconds: Job runtime in seconds.
+    """
+
+    job: StitchJob
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed_seconds: float
+
+
+def expand_raster_list_args(raster_list_args: Sequence[str]) -> list[Path]:
+    """Expand raster-list file arguments and glob patterns.
+
+    Args:
+        raster_list_args: Command-line arguments. Each argument may be a
+            concrete path or a glob pattern.
+
+    Returns:
+        Ordered, de-duplicated list of raster-list paths.
+
+    Raises:
+        ValueError: If no files are found or a glob pattern does not match.
+        FileNotFoundError: If a concrete path does not exist.
+    """
+    raster_list_paths: list[Path] = []
+    seen_paths: set[Path] = set()
+    for raster_list_arg in raster_list_args:
+        has_glob = any(char in raster_list_arg for char in "*?[")
+        if has_glob:
+            matches = sorted(glob.glob(raster_list_arg))
+            if not matches:
+                raise ValueError(f"No files matched glob: {raster_list_arg}")
+            candidate_paths = [Path(match) for match in matches]
+        else:
+            candidate_path = Path(raster_list_arg)
+            if not candidate_path.exists():
+                raise FileNotFoundError(candidate_path)
+            candidate_paths = [candidate_path]
+
+        for candidate_path in candidate_paths:
+            resolved_path = candidate_path.resolve()
+            if resolved_path in seen_paths:
+                continue
+            seen_paths.add(resolved_path)
+            raster_list_paths.append(resolved_path)
+
+    if not raster_list_paths:
+        raise ValueError("No raster-list files were provided.")
+    return raster_list_paths
+
+
+def build_stitch_jobs(
+    raster_list_paths: Sequence[Path],
+    output_dir: Path | None,
+    output_suffix: str,
+) -> list[StitchJob]:
+    """Build stitch jobs from input list files.
+
+    Args:
+        raster_list_paths: Paths to text files listing rasters.
+        output_dir: Optional directory where all stitched rasters should be
+            written. If ``None``, each output is written beside its input list.
+        output_suffix: Suffix inserted between each list-file stem and
+            ``.tif``. For example, ``"_stitched"`` creates
+            ``name_stitched.tif``.
+
+    Returns:
+        Ordered list of ``StitchJob`` instances.
+    """
+    jobs = []
+    for raster_list_path in raster_list_paths:
+        target_dir = Path(output_dir).resolve() if output_dir else raster_list_path.parent
+        output_raster_path = target_dir / f"{raster_list_path.stem}{output_suffix}.tif"
+        jobs.append(
+            StitchJob(
+                raster_list_path=raster_list_path.resolve(),
+                output_raster_path=output_raster_path.resolve(),
+            )
+        )
+    return jobs
+
+
+def run_stitch_job(
+    job: StitchJob,
+    stitcher_script_path: Path,
+    python_executable: str,
+) -> StitchResult:
+    """Run one stitch job as a child Python process.
+
+    Args:
+        job: Stitch job to execute.
+        stitcher_script_path: Path to ``high_performance_stitch_rasters.py``.
+        python_executable: Python executable used to launch the stitcher.
+
+    Returns:
+        ``StitchResult`` with captured output and runtime.
+    """
+    start_time = time.monotonic()
+    completed_process = subprocess.run(
+        [
+            python_executable,
+            os.fspath(stitcher_script_path),
+            os.fspath(job.raster_list_path),
+            os.fspath(job.output_raster_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return StitchResult(
+        job=job,
+        returncode=completed_process.returncode,
+        stdout=completed_process.stdout,
+        stderr=completed_process.stderr,
+        elapsed_seconds=time.monotonic() - start_time,
+    )
+
+
+def run_stitch_jobs(
+    jobs: Sequence[StitchJob],
+    workers: int,
+    stitcher_script_path: Path,
+    python_executable: str,
+    status_interval_seconds: int = DEFAULT_STATUS_INTERVAL_SECONDS,
+) -> list[StitchResult]:
+    """Run stitch jobs in parallel with a worker limit.
+
+    Args:
+        jobs: Stitch jobs to execute.
+        workers: Maximum number of jobs to run at the same time.
+        stitcher_script_path: Path to ``high_performance_stitch_rasters.py``.
+        python_executable: Python executable used to launch each job.
+        status_interval_seconds: Seconds between status messages while jobs
+            are still running.
+
+    Returns:
+        Ordered list of completed ``StitchResult`` objects in completion order.
+
+    Raises:
+        ValueError: If ``workers`` is less than 1.
+    """
+    if workers < 1:
+        raise ValueError(f"workers must be at least 1, got {workers}")
+
+    results: list[StitchResult] = []
+    futures_to_jobs = {}
+    start_time = time.monotonic()
+    last_status_time = start_time
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        for job in jobs:
+            future = executor.submit(
+                run_stitch_job,
+                job,
+                stitcher_script_path,
+                python_executable,
+            )
+            futures_to_jobs[future] = job
+
+        pending_futures = set(futures_to_jobs)
+        while pending_futures:
+            done_futures, pending_futures = wait(
+                pending_futures,
+                timeout=1,
+                return_when=FIRST_COMPLETED,
+            )
+
+            for future in done_futures:
+                result = future.result()
+                results.append(result)
+                status = "ok" if result.returncode == 0 else "failed"
+                print(
+                    f"[{len(results)}/{len(jobs)}] {status}: "
+                    f"{result.job.raster_list_path.name} "
+                    f"({result.elapsed_seconds:.1f}s)"
+                )
+                if result.stdout:
+                    print(result.stdout.rstrip())
+                if result.stderr:
+                    print(result.stderr.rstrip(), file=sys.stderr)
+
+            now = time.monotonic()
+            if (
+                pending_futures
+                and status_interval_seconds > 0
+                and now - last_status_time >= status_interval_seconds
+            ):
+                running_names = [
+                    futures_to_jobs[future].raster_list_path.name
+                    for future in pending_futures
+                ]
+                print(
+                    f"still running {len(pending_futures)} job(s) after "
+                    f"{now - start_time:.0f}s: {', '.join(running_names)}"
+                )
+                last_status_time = now
+
+    return results
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser.
+
+    Returns:
+        Configured argument parser for the parallel stitch runner.
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run high_performance_stitch_rasters.py for many raster-list text "
+            "files with a fixed worker limit."
+        )
+    )
+    parser.add_argument(
+        "raster_lists",
+        nargs="+",
+        help=(
+            "Raster-list text files or glob patterns. Each list becomes one "
+            "stitched GeoTIFF."
+        ),
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=4,
+        help="Maximum number of stitch jobs to run at once. Default: 4.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional directory for stitched rasters. Defaults to each list "
+            "file's directory."
+        ),
+    )
+    parser.add_argument(
+        "--output-suffix",
+        default="",
+        help=(
+            "Suffix inserted before .tif in output names. Example: "
+            "--output-suffix _stitched creates name_stitched.tif."
+        ),
+    )
+    parser.add_argument(
+        "--stitcher-script",
+        type=Path,
+        default=Path(__file__).with_name("high_performance_stitch_rasters.py"),
+        help="Path to high_performance_stitch_rasters.py.",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable used for child stitch processes.",
+    )
+    parser.add_argument(
+        "--status-interval",
+        type=int,
+        default=DEFAULT_STATUS_INTERVAL_SECONDS,
+        help="Seconds between running-job status messages. Use 0 to disable.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Run the CLI."""
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    raster_list_paths = expand_raster_list_args(args.raster_lists)
+    jobs = build_stitch_jobs(
+        raster_list_paths,
+        args.output_dir,
+        args.output_suffix,
+    )
+    print(f"running {len(jobs)} stitch job(s) with {args.workers} worker(s)")
+
+    results = run_stitch_jobs(
+        jobs,
+        args.workers,
+        args.stitcher_script.resolve(),
+        args.python,
+        args.status_interval,
+    )
+    failed_results = [result for result in results if result.returncode != 0]
+    if failed_results:
+        failed_names = ", ".join(
+            result.job.raster_list_path.name for result in failed_results
+        )
+        raise SystemExit(f"{len(failed_results)} stitch job(s) failed: {failed_names}")
+    print("all stitch jobs completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/run_parallel_stitch_rasters.py
+++ b/utils/run_parallel_stitch_rasters.py
@@ -444,8 +444,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--nodata",
         default=None,
         help=(
-            "Override nodata for each stitched output and ignore this value "
-            "in every input raster."
+            "Use this nodata value when the first raster in a stitch job does "
+            "not define one, and ignore this value in every input raster."
         ),
     )
     return parser


### PR DESCRIPTION
## Summary
- Add `utils/run_parallel_stitch_rasters.py` to run multiple standalone raster stitch jobs with a configurable worker limit.
- Add tqdm-style progress for overall jobs and active worker stages.
- Support UTF-8/UTF-16 raster-list files from Windows shells.
- Bound the stitcher GDAL cache to reduce per-worker memory growth.
- Add `--nodata VALUE` so the stitcher uses that value only when the first raster has no nodata metadata, sets output nodata, and skips that value from every input raster.
- Keep first/reference raster nodata metadata authoritative when it already exists.
- Add focused tests for runner job setup, raster-list reading, compression, progress events, and nodata override behavior.

Closes #72
Closes #74

## Testing
- `mamba run -n py311 python -m unittest tests.test_high_performance_stitch_rasters tests.test_run_parallel_stitch_rasters`
- `mamba run -n py311 python -m py_compile utils\\high_performance_stitch_rasters.py utils\\run_parallel_stitch_rasters.py`
- `git diff --check`

## Notes
- This follow-up PR contains the parallel runner commit that was created after PR #71 had already merged.