### PR TITLE
Fix condition mask nodata handling

### DIFF
--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -37,7 +37,7 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
             ),
         )
 
-    def test_downstream_coverage_mask_ignores_tiny_convolution_noise(self):
+    def test_downstream_coverage_threshold_ignores_tiny_convolution_noise(self):
         mask = np.array(
             [
                 [0.0, np.finfo(float).eps],
@@ -46,7 +46,7 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
             dtype=np.float64,
         )
 
-        result = workflow_runner.downstream_coverage_mask(mask)
+        result = mask > workflow_runner.DOWNSTREAM_COVERAGE_EPSILON
 
         np.testing.assert_array_equal(
             result,

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -33,6 +33,27 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
             ),
         )
 
+    def test_downstream_coverage_mask_ignores_tiny_convolution_noise(self):
+        mask = np.array(
+            [
+                [0.0, np.finfo(float).eps],
+                [200 * np.finfo(float).eps, 1.0],
+            ],
+            dtype=np.float64,
+        )
+
+        result = workflow_runner.downstream_coverage_mask(mask)
+
+        np.testing.assert_array_equal(
+            result,
+            np.array(
+                [
+                    [False, False],
+                    [True, True],
+                ]
+            ),
+        )
+
     def test_bounds_mask_includes_wgs84_pixel_centers(self):
         mask = workflow_runner._rasterize_wgs84_bounds_mask(
             (-1.5, -0.5, 1.5, 1.5),

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -11,6 +11,28 @@ import workflow_runner
 
 class Wgs84BoundsMaskTests(unittest.TestCase):
 
+    def test_condition_mask_treats_source_nodata_as_false(self):
+        value = np.array(
+            [
+                [5, -9999],
+                [0, 7],
+            ],
+            dtype=np.int16,
+        )
+
+        result = workflow_runner.condition_mask_op(value, -9999, "value > 0")
+
+        np.testing.assert_array_equal(
+            result,
+            np.array(
+                [
+                    [1, 0],
+                    [0, 1],
+                ],
+                dtype=np.uint8,
+            ),
+        )
+
     def test_bounds_mask_includes_wgs84_pixel_centers(self):
         mask = workflow_runner._rasterize_wgs84_bounds_mask(
             (-1.5, -0.5, 1.5, 1.5),

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -20,7 +20,11 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
             dtype=np.int16,
         )
 
-        result = workflow_runner.condition_mask_op(value, -9999, "value > 0")
+        condition_mask_op = workflow_runner.make_condition_mask_op(
+            -9999,
+            "value > 0",
+        )
+        result = condition_mask_op(value)
 
         np.testing.assert_array_equal(
             result,

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1573,28 +1573,33 @@ def create_distance_transform(
     base_raster = None
 
 
-def condition_mask_op(value, base_raster_nodata, expression):
-    """Evaluate a conditional raster expression into a binary mask.
+def make_condition_mask_op(base_raster_nodata, expression):
+    """Build a raster calculator op for a binary condition mask.
 
-    Source nodata pixels are always false. This keeps nodata values from
-    leaking into the downstream source mask as nonzero byte values.
+    The returned function evaluates ``expression`` only on valid source pixels.
+    Source nodata pixels are always false so they cannot leak into the
+    downstream source mask as nonzero byte values.
     """
-    result = np.zeros(value.shape, dtype=np.uint8)
-    valid_mask = (
-        np.ones(value.shape, dtype=bool)
-        if base_raster_nodata is None
-        else value != base_raster_nodata
-    )
-    if not np.any(valid_mask):
+
+    def _condition_mask_op(value):
+        result = np.zeros(value.shape, dtype=np.uint8)
+        valid_mask = (
+            np.ones(value.shape, dtype=bool)
+            if base_raster_nodata is None
+            else value != base_raster_nodata
+        )
+        if not np.any(valid_mask):
+            return result
+
+        expression_result = eval(
+            expression,
+            {"__builtins__": {}},
+            {"value": value[valid_mask], "np": np},
+        )
+        result[valid_mask] = np.asarray(expression_result).astype(bool).astype(np.uint8)
         return result
 
-    expression_result = eval(
-        expression,
-        {"__builtins__": {}},
-        {"value": value[valid_mask], "np": np},
-    )
-    result[valid_mask] = np.asarray(expression_result).astype(bool).astype(np.uint8)
-    return result
+    return _condition_mask_op
 
 
 def downstream_coverage_mask(mask):
@@ -1687,12 +1692,9 @@ def calculate_ds_pop_from_conditional_raster(
 
     base_raster_nodata = base_info["nodata"][0]
 
-    def _local_op(value):
-        return condition_mask_op(value, base_raster_nodata, expression)
-
     geoprocessing.raster_calculator(
         [(str(clipped_base_raster_path), 1)],
-        _local_op,
+        make_condition_mask_op(base_raster_nodata, expression),
         condition_raster_path,
         gdal.GDT_Byte,
         0,

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1602,11 +1602,6 @@ def make_condition_mask_op(base_raster_nodata, expression):
     return _condition_mask_op
 
 
-def downstream_coverage_mask(mask):
-    """Return true where downstream coverage is meaningfully nonzero."""
-    return mask > DOWNSTREAM_COVERAGE_EPSILON
-
-
 def calculate_ds_pop_from_conditional_raster(
     aoi_vector_path,
     flow_dir_raster_path,
@@ -1734,7 +1729,7 @@ def calculate_ds_pop_from_conditional_raster(
         def _distance_mask_op(mask, n_pixels):
             return (
                 (n_pixels != DISTANCE_TRANSFORM_NODATA)
-                & downstream_coverage_mask(mask)
+                & (mask > DOWNSTREAM_COVERAGE_EPSILON)
                 & (n_pixels * travel_time_pixel_size_m <= max_downstream_distance_m)
             )
 
@@ -1766,7 +1761,11 @@ def calculate_ds_pop_from_conditional_raster(
     def mask_op(mask, pop_val):
         # mask values come from convolve so they can be veeeeeery close
         # to 0 without being 0 when the should be, so we just cap that here
-        return np.where(downstream_coverage_mask(mask) & (pop_val > 0), pop_val, 0)
+        return np.where(
+            (mask > DOWNSTREAM_COVERAGE_EPSILON) & (pop_val > 0),
+            pop_val,
+            0,
+        )
 
     pop_info = geoprocessing.get_raster_info(clipped_pop_raster_path)
     geoprocessing.raster_calculator(

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -63,6 +63,7 @@ HEARTBEAT_INTERVAL_SECONDS = 60
 TRAVEL_TIME_MAX_DISTANCE_M_PER_HOUR = 104_000
 POPULATION_COMBINE_VRT_NODATA = -1
 DISTANCE_TRANSFORM_NODATA = -1
+DOWNSTREAM_COVERAGE_EPSILON = 100 * np.finfo(float).eps
 GTIFF_CREATION_OPTIONS = (
     "TILED=YES",
     "BIGTIFF=YES",
@@ -1596,6 +1597,11 @@ def condition_mask_op(value, base_raster_nodata, expression):
     return result
 
 
+def downstream_coverage_mask(mask):
+    """Return true where downstream coverage is meaningfully nonzero."""
+    return mask > DOWNSTREAM_COVERAGE_EPSILON
+
+
 def calculate_ds_pop_from_conditional_raster(
     aoi_vector_path,
     flow_dir_raster_path,
@@ -1726,7 +1732,7 @@ def calculate_ds_pop_from_conditional_raster(
         def _distance_mask_op(mask, n_pixels):
             return (
                 (n_pixels != DISTANCE_TRANSFORM_NODATA)
-                & mask.astype(bool)
+                & downstream_coverage_mask(mask)
                 & (n_pixels * travel_time_pixel_size_m <= max_downstream_distance_m)
             )
 
@@ -1758,7 +1764,7 @@ def calculate_ds_pop_from_conditional_raster(
     def mask_op(mask, pop_val):
         # mask values come from convolve so they can be veeeeeery close
         # to 0 without being 0 when the should be, so we just cap that here
-        return np.where((mask > 100 * np.finfo(float).eps) & (pop_val > 0), pop_val, 0)
+        return np.where(downstream_coverage_mask(mask) & (pop_val > 0), pop_val, 0)
 
     pop_info = geoprocessing.get_raster_info(clipped_pop_raster_path)
     geoprocessing.raster_calculator(

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1572,6 +1572,30 @@ def create_distance_transform(
     base_raster = None
 
 
+def condition_mask_op(value, base_raster_nodata, expression):
+    """Evaluate a conditional raster expression into a binary mask.
+
+    Source nodata pixels are always false. This keeps nodata values from
+    leaking into the downstream source mask as nonzero byte values.
+    """
+    result = np.zeros(value.shape, dtype=np.uint8)
+    valid_mask = (
+        np.ones(value.shape, dtype=bool)
+        if base_raster_nodata is None
+        else value != base_raster_nodata
+    )
+    if not np.any(valid_mask):
+        return result
+
+    expression_result = eval(
+        expression,
+        {"__builtins__": {}},
+        {"value": value[valid_mask], "np": np},
+    )
+    result[valid_mask] = np.asarray(expression_result).astype(bool).astype(np.uint8)
+    return result
+
+
 def calculate_ds_pop_from_conditional_raster(
     aoi_vector_path,
     flow_dir_raster_path,
@@ -1658,34 +1682,14 @@ def calculate_ds_pop_from_conditional_raster(
     base_raster_nodata = base_info["nodata"][0]
 
     def _local_op(value):
-        """Applies an elementwise expression to an array with nodata masking.
-
-        Note: `base_raster_nodata` and `expression` are provided in the outside
-            closure.
-
-        Args:
-            value (np.ndarray): Input array.
-
-        Returns:
-            np.ndarray: Array with the expression applied to valid elements.
-        """
-        result = value.copy()
-        valid_mask = (
-            slice(None) if base_raster_nodata is None else value != base_raster_nodata
-        )
-        result[valid_mask] = eval(
-            expression,
-            {"__builtins__": {}},
-            {"value": value[valid_mask], "np": np},
-        )
-        return result
+        return condition_mask_op(value, base_raster_nodata, expression)
 
     geoprocessing.raster_calculator(
         [(str(clipped_base_raster_path), 1)],
         _local_op,
         condition_raster_path,
         gdal.GDT_Byte,
-        None,
+        0,
         calc_raster_stats=False,
         raster_driver_creation_tuple=GTIFF_CREATION_TUPLE,
     )
@@ -2115,7 +2119,9 @@ def combine_pops(
 
     logger.info("wrote combined population raster %s", target_combined_pop_raster_path)
 
-    logger.info("summing combined population raster %s", target_combined_pop_raster_path)
+    logger.info(
+        "summing combined population raster %s", target_combined_pop_raster_path
+    )
     with _log_heartbeat(
         logger,
         lambda: f"summing combined population raster {target_combined_pop_raster_path}",
@@ -2315,8 +2321,7 @@ def main() -> None:
                 travel_time_working_dir = working_dir / section_id
                 travel_time_working_dir.mkdir(parents=True, exist_ok=True)
                 use_wgs84_bounds_mask = (
-                    aoi_key == FULL_RASTER_EXTENT_AOI_ID
-                    and debug_drain_index is None
+                    aoi_key == FULL_RASTER_EXTENT_AOI_ID and debug_drain_index is None
                 )
 
                 travel_task = task_graph.add_task(


### PR DESCRIPTION
## Summary
- Add a binary condition-mask operation factory for conditional raster expressions.
- Treat condition-raster source nodata as false/0 so nodata cannot become a downstream source pixel.
- Write the generated condition mask with nodata value `0`.
- Use a shared downstream coverage threshold before treating convolved coverage as true, including the max-distance mask step.
- Add regression tests for nonzero source nodata leaking into the condition mask and tiny convolution noise becoming coverage.

Closes #75

## Testing
- `mamba run -n py311 python -m unittest tests.test_workflow_runner`
- `mamba run -n py311 python -m py_compile workflow_runner.py tests\\test_workflow_runner.py`
- `git diff --check`

## Notes
- `workflow_runner.py` already had two formatting-only local line-wrap changes before this bugfix; they are included in the first commit but do not change behavior.