### PR TITLE
Move drain population intermediates

### DIFF
--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1,5 +1,4 @@
 import unittest
-from pathlib import Path
 
 import numpy as np
 from pyproj import CRS, Transformer
@@ -11,30 +10,6 @@ import workflow_runner
 
 
 class Wgs84BoundsMaskTests(unittest.TestCase):
-
-    def test_conditional_partition_output_uses_section_output_for_single_partition(self):
-        section_output_path = Path("output") / "full_raster_extent_downstream_pop.tif"
-
-        result = workflow_runner.conditional_partition_pop_raster_path(
-            1,
-            section_output_path,
-            Path("work") / "full_raster_extent" / "drain_1",
-            "downstream",
-        )
-
-        self.assertEqual(result, section_output_path)
-
-    def test_conditional_partition_output_uses_workspace_for_multi_partition(self):
-        partition_working_dir = Path("work") / "full_raster_extent" / "drain_1"
-
-        result = workflow_runner.conditional_partition_pop_raster_path(
-            2,
-            Path("output") / "full_raster_extent_downstream_pop.tif",
-            partition_working_dir,
-            "downstream",
-        )
-
-        self.assertEqual(result, partition_working_dir / "downstream_pop.tif")
 
     def test_condition_mask_treats_source_nodata_as_false(self):
         value = np.array(

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 import numpy as np
 from pyproj import CRS, Transformer
@@ -10,6 +11,30 @@ import workflow_runner
 
 
 class Wgs84BoundsMaskTests(unittest.TestCase):
+
+    def test_conditional_partition_output_uses_section_output_for_single_partition(self):
+        section_output_path = Path("output") / "full_raster_extent_downstream_pop.tif"
+
+        result = workflow_runner.conditional_partition_pop_raster_path(
+            1,
+            section_output_path,
+            Path("work") / "full_raster_extent" / "drain_1",
+            "downstream",
+        )
+
+        self.assertEqual(result, section_output_path)
+
+    def test_conditional_partition_output_uses_workspace_for_multi_partition(self):
+        partition_working_dir = Path("work") / "full_raster_extent" / "drain_1"
+
+        result = workflow_runner.conditional_partition_pop_raster_path(
+            2,
+            Path("output") / "full_raster_extent_downstream_pop.tif",
+            partition_working_dir,
+            "downstream",
+        )
+
+        self.assertEqual(result, partition_working_dir / "downstream_pop.tif")
 
     def test_condition_mask_treats_source_nodata_as_false(self):
         value = np.array(

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -2170,23 +2170,6 @@ def calculate_taskgraph_worker_count(config: dict, work_unit_count: int) -> int:
     return min(desired_worker_count, physical_cpu_count)
 
 
-def conditional_partition_pop_raster_path(
-    partition_context_count: int,
-    section_pop_raster_path: Path,
-    partition_working_dir: Path,
-    section_id: str,
-) -> Path:
-    """Return the output path for one conditional partition population raster.
-
-    When there is only one partition, the partition output is also the final
-    section output. When multiple partitions are present, each partition raster
-    is an intermediate and belongs in that partition's workspace.
-    """
-    if partition_context_count == 1:
-        return section_pop_raster_path
-    return partition_working_dir / f"{section_id}_pop.tif"
-
-
 def main() -> None:
     """Entry point."""
     ap = argparse.ArgumentParser(
@@ -2372,12 +2355,12 @@ def main() -> None:
                     partition_id,
                     partition_context,
                 ) in partition_contexts.items():
-                    partition_pop_raster_path = conditional_partition_pop_raster_path(
-                        len(partition_contexts),
-                        target_pop_raster_path,
-                        partition_context["working_dir"],
-                        section_id,
-                    )
+                    if len(partition_contexts) == 1:
+                        partition_pop_raster_path = target_pop_raster_path
+                    else:
+                        partition_pop_raster_path = (
+                            partition_context["working_dir"] / f"{section_id}_pop.tif"
+                        )
                     partition_pop_id_raster_list.append(
                         (partition_id, partition_pop_raster_path)
                     )

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -2170,6 +2170,23 @@ def calculate_taskgraph_worker_count(config: dict, work_unit_count: int) -> int:
     return min(desired_worker_count, physical_cpu_count)
 
 
+def conditional_partition_pop_raster_path(
+    partition_context_count: int,
+    section_pop_raster_path: Path,
+    partition_working_dir: Path,
+    section_id: str,
+) -> Path:
+    """Return the output path for one conditional partition population raster.
+
+    When there is only one partition, the partition output is also the final
+    section output. When multiple partitions are present, each partition raster
+    is an intermediate and belongs in that partition's workspace.
+    """
+    if partition_context_count == 1:
+        return section_pop_raster_path
+    return partition_working_dir / f"{section_id}_pop.tif"
+
+
 def main() -> None:
     """Entry point."""
     ap = argparse.ArgumentParser(
@@ -2355,13 +2372,12 @@ def main() -> None:
                     partition_id,
                     partition_context,
                 ) in partition_contexts.items():
-                    if len(partition_contexts) == 1:
-                        partition_pop_raster_path = target_pop_raster_path
-                    else:
-                        partition_pop_raster_path = (
-                            output_dir
-                            / f"{aoi_key}_{partition_id}_{section_id}_pop.tif"
-                        )
+                    partition_pop_raster_path = conditional_partition_pop_raster_path(
+                        len(partition_contexts),
+                        target_pop_raster_path,
+                        partition_context["working_dir"],
+                        section_id,
+                    )
                     partition_pop_id_raster_list.append(
                         (partition_id, partition_pop_raster_path)
                     )


### PR DESCRIPTION
## Summary
- Write multi-partition per-drain conditional population rasters into each partition workspace instead of the top-level output directory.
- Keep single-partition/debug output behavior unchanged so the selected drain still writes the section output directly.

Closes #77

## Testing
- `mamba run -n py311 python -m unittest tests.test_workflow_runner`
- `mamba run -n py311 python -m py_compile workflow_runner.py tests\\test_workflow_runner.py`
- `git diff --check`