### PR TITLE
Throttle workflow workers and report memory pressure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ configs/
 !configs/example_roadmap2030_pop_downstream_analysis.yaml
 data/
 configs/
+output*

--- a/shortest_distances/src/shortest_distances.pyx
+++ b/shortest_distances/src/shortest_distances.pyx
@@ -71,8 +71,9 @@ def find_mask_reach(
         float cell_length_m,
         int n_cols, int n_rows,
         float max_time,
-        int progress_interval_seconds=10):
-    """Define later
+        int progress_interval_seconds=10,
+        int queue_guard_multiplier=3):
+    """Calculate the pixels reachable from a source mask.
 
     Parameters:
         friction_array (numpy.ndarray): array with friction values for
@@ -85,6 +86,13 @@ def find_mask_reach(
         progress_interval_seconds (int): minimum number of seconds between
             travel-reach heartbeat log messages. Set to 0 to disable progress
             logging.
+        queue_guard_multiplier (int): Fail if the internal priority queue
+            exceeds this multiple of the input raster pixel count.
+
+    Raises:
+        MemoryError: If the internal priority queue grows beyond
+            ``queue_guard_multiplier`` times the number of pixels in
+            ``friction_array``.
 
     Returns:
         2D array of mask reach of the same size as input arrays.
@@ -114,7 +122,11 @@ def find_mask_reach(
     cdef double pop_rate = 0
     cdef double frontier_percent = 0
     cdef size_t queue_size
+    cdef size_t pixel_count = <size_t>n_cols * <size_t>n_rows
+    cdef size_t queue_guard_limit = <size_t>queue_guard_multiplier * pixel_count
+    cdef size_t queue_size_at_guard = 0
     cdef bint report_needed = False
+    cdef bint queue_guard_exceeded = False
 
     cdef DistPriorityQueueType dist_queue
     cdef ValuePixelType pixel
@@ -241,10 +253,24 @@ def find_mask_reach(
                     pixel.i = i_n
                     pixel.j = j_n
                     dist_queue.push(pixel)
+                    queue_size = dist_queue.size()
+                    if queue_size > queue_guard_limit:
+                        queue_size_at_guard = queue_size
+                        queue_guard_exceeded = True
+                        break
+
+                if queue_guard_exceeded:
+                    break
 
                 if report_needed:
                     queue_size = dist_queue.size()
                     break
+        if queue_guard_exceeded:
+            raise MemoryError(
+                "travel reach priority queue exceeded guard limit: "
+                f"queue={queue_size_at_guard}, limit={queue_guard_limit}, "
+                f"raster={n_cols}x{n_rows} px, pops={pop_count}, "
+                f"covered={covered_count} px, max_time={max_time:.1f} min")
         if report_needed:
             LOGGER.info(
                 "travel reach heartbeat: frontier=%.1f/%.1f min "

--- a/shortest_distances/src/shortest_distances.pyx
+++ b/shortest_distances/src/shortest_distances.pyx
@@ -23,6 +23,7 @@ import numpy
 
 cimport cython
 cimport numpy
+from libc.math cimport isfinite
 from libc.math cimport sqrt
 from libc.time cimport time as ctime
 from libc.time cimport time_t
@@ -153,7 +154,8 @@ def find_mask_reach(
                         continue
                     if mask_array[j_n, i_n] != 0:
                         continue
-                    if friction_array[j_n, i_n] <= 0:
+                    frict_n = friction_array[j_n, i_n]
+                    if not isfinite(frict_n) or frict_n <= 0:
                         continue
                     is_frontier = True
                     break
@@ -234,7 +236,7 @@ def find_mask_reach(
                         continue
                     frict_n = friction_array[j_n, i_n]
                     # the nodata value is undefined but will present as 0.
-                    if frict_n <= 0:
+                    if not isfinite(frict_n) or frict_n <= 0:
                         continue
                     if v & 1:  # if msd is 1, it's odd
                         edge_weight = frict_n*diag_cell_length_m

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -261,6 +261,26 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
 
         np.testing.assert_array_equal(result, expected)
 
+    def test_travel_reach_priority_queue_guard_reports_window_context(self):
+        friction = np.ones((3, 3), dtype=np.float32)
+        source_mask = np.zeros((3, 3), dtype=np.int8)
+        source_mask[1, 1] = 1
+
+        with self.assertRaisesRegex(
+            MemoryError,
+            "travel reach priority queue exceeded guard limit",
+        ):
+            workflow_runner.shortest_distances.find_mask_reach(
+                friction,
+                source_mask,
+                1.0,
+                3,
+                3,
+                2.0,
+                progress_interval_seconds=0,
+                queue_guard_multiplier=0,
+            )
+
     def test_mask_population_with_coverage_applies_coverage_once(self):
         transform = from_origin(0, 2, 1, 1)
         coverage_profile = {

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -281,6 +281,25 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
                 queue_guard_multiplier=0,
             )
 
+    def test_travel_reach_ignores_nan_friction(self):
+        friction = np.ones((3, 3), dtype=np.float32)
+        friction[1, 2] = np.nan
+        source_mask = np.zeros((3, 3), dtype=np.int8)
+        source_mask[1, 1] = 1
+
+        result = workflow_runner.shortest_distances.find_mask_reach(
+            friction,
+            source_mask,
+            1.0,
+            3,
+            3,
+            2.0,
+            progress_interval_seconds=0,
+        )
+
+        self.assertEqual(result[1, 2], 0)
+        self.assertEqual(result[1, 1], 1)
+
     def test_mask_population_with_coverage_applies_coverage_once(self):
         transform = from_origin(0, 2, 1, 1)
         coverage_profile = {

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -4,6 +4,7 @@ from unittest import mock
 from pathlib import Path
 import tempfile
 
+import geopandas as gpd
 import numpy as np
 import rasterio
 from pyproj import CRS, Transformer
@@ -161,6 +162,44 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
             1,
         )
         self.assertEqual(mask[0, 0], 1)
+
+    def test_mask_raster_to_vector_sets_default_nodata_outside_geometry(self):
+        raster_profile = {
+            "driver": "GTiff",
+            "height": 4,
+            "width": 4,
+            "count": 1,
+            "dtype": "int16",
+            "crs": "EPSG:4326",
+            "transform": from_origin(0, 4, 1, 1),
+        }
+        workflow_runner._set_tiled_geotiff_creation_options(raster_profile)
+
+        with tempfile.TemporaryDirectory() as workspace:
+            workspace_path = Path(workspace)
+            raster_path = workspace_path / "dem.tif"
+            vector_path = workspace_path / "mask.gpkg"
+            raster_array = np.arange(16, dtype=np.int16).reshape((4, 4))
+            raster_array[1, 1] = 0
+            with rasterio.open(raster_path, "w", **raster_profile) as raster:
+                raster.write(raster_array, 1)
+            gpd.GeoDataFrame(
+                geometry=[box(0, 0, 2, 4)],
+                crs="EPSG:4326",
+            ).to_file(vector_path, driver="GPKG")
+
+            workflow_runner.mask_raster_to_vector(raster_path, vector_path)
+
+            with rasterio.open(raster_path) as masked_raster:
+                masked_array = masked_raster.read(1)
+                nodata = masked_raster.nodata
+
+        self.assertEqual(nodata, np.iinfo(np.int16).min)
+        self.assertEqual(masked_array[1, 1], 0)
+        np.testing.assert_array_equal(
+            masked_array[:, 2:],
+            np.full((4, 2), np.iinfo(np.int16).min, dtype=np.int16),
+        )
 
     def test_stitch_coverage_masks_uses_union_semantics(self):
         profile = {

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -8,6 +8,7 @@ import numpy as np
 import rasterio
 from pyproj import CRS, Transformer
 from rasterio.transform import from_origin
+from rasterio.windows import from_bounds
 from shapely.geometry import Point, box
 from shapely.ops import transform
 
@@ -206,6 +207,37 @@ class Wgs84BoundsMaskTests(unittest.TestCase):
         np.testing.assert_array_equal(
             result,
             np.array([[1, 1], [0, 0]], dtype=np.uint8),
+        )
+
+    def test_antimeridian_bounds_split_into_valid_wgs84_windows(self):
+        bounds = (167.7408, 66.7660, -179.1999, 70.0103)
+
+        split_bounds = workflow_runner._split_wgs84_antimeridian_bounds(bounds)
+
+        self.assertEqual(
+            split_bounds,
+            [
+                (167.7408, 66.7660, 180.0, 70.0103),
+                (-180.0, 66.7660, -179.1999, 70.0103),
+            ],
+        )
+        transform = from_origin(-180, 90, 1, 1)
+        for bounds_part in split_bounds:
+            window = workflow_runner._integer_window(
+                from_bounds(*bounds_part, transform=transform),
+                360,
+                180,
+            )
+            self.assertGreater(window.width, 0)
+            self.assertGreater(window.height, 0)
+        pixel_size = 0.008333333333333
+        self.assertAlmostEqual(
+            workflow_runner._floor_to_grid(-180.0, pixel_size),
+            -180.0,
+        )
+        self.assertAlmostEqual(
+            workflow_runner._ceil_to_grid(180.0, pixel_size),
+            180.0,
         )
 
     def test_windowed_travel_reach_matches_whole_raster_reach(self):

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1,5 +1,6 @@
 import unittest
 import warnings
+from unittest import mock
 from pathlib import Path
 import tempfile
 
@@ -14,6 +15,37 @@ import workflow_runner
 
 
 class Wgs84BoundsMaskTests(unittest.TestCase):
+
+    def test_conditional_workflows_default_to_two_workers(self):
+        config = {
+            "inputs": {"taskgraph_workers": None},
+            "masks": [
+                {"type": "travel_time_population"},
+                {"type": "conditional_raster"},
+            ],
+        }
+
+        with mock.patch("workflow_runner.psutil.cpu_count", return_value=16):
+            worker_count = workflow_runner.calculate_taskgraph_worker_count(
+                config,
+                work_unit_count=5421,
+            )
+
+        self.assertEqual(worker_count, 2)
+
+    def test_configured_taskgraph_workers_override_default_and_cap_at_cpu_count(self):
+        config = {
+            "inputs": {"taskgraph_workers": 99},
+            "masks": [{"type": "conditional_raster"}],
+        }
+
+        with mock.patch("workflow_runner.psutil.cpu_count", return_value=16):
+            worker_count = workflow_runner.calculate_taskgraph_worker_count(
+                config,
+                work_unit_count=5421,
+            )
+
+        self.assertEqual(worker_count, 16)
 
     def test_is_eckert_iv_crs_detects_projection_without_proj4_warning(self):
         eckert_crs = CRS.from_proj4("+proj=eck4 +R=6371000 +units=m +no_defs")

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -60,6 +60,9 @@ import shortest_distances
 
 RASTER_BLOCK_SIZE = 256
 HEARTBEAT_INTERVAL_SECONDS = 60
+DEFAULT_GDAL_CACHEMAX_MB = 128
+DEFAULT_CONDITIONAL_TASKGRAPH_WORKERS = 2
+DEFAULT_TRAVEL_TIME_TASKGRAPH_WORKERS = 4
 TRAVEL_TIME_MAX_DISTANCE_M_PER_HOUR = 104_000
 POPULATION_COMBINE_VRT_NODATA = -1
 DISTANCE_TRANSFORM_NODATA = -1
@@ -73,6 +76,56 @@ GTIFF_CREATION_OPTIONS = (
     "NUM_THREADS=ALL_CPUS",
 )
 GTIFF_CREATION_TUPLE = ("GTIFF", GTIFF_CREATION_OPTIONS)
+
+
+def _format_bytes(size_bytes: int | float) -> str:
+    """Return a compact human-readable byte size."""
+    size = float(size_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(size) < 1024 or unit == "TiB":
+            return f"{size:.1f}{unit}"
+        size /= 1024
+
+
+def configure_gdal_cache(cachemax_mb: int | None = None) -> int:
+    """Set GDAL's per-process cache limit and return it in MiB."""
+    if cachemax_mb is None:
+        cachemax_mb = int(os.environ.get("GDAL_CACHEMAX", DEFAULT_GDAL_CACHEMAX_MB))
+    cachemax_mb = int(cachemax_mb)
+    os.environ["GDAL_CACHEMAX"] = str(cachemax_mb)
+    cachemax_bytes = cachemax_mb * 1024 * 1024
+    if hasattr(gdal, "SetCacheMax64"):
+        gdal.SetCacheMax64(cachemax_bytes)
+    else:
+        gdal.SetCacheMax(cachemax_bytes)
+    return cachemax_mb
+
+
+def _process_tree_rss_bytes() -> int:
+    """Return RSS for this process and any living child processes."""
+    total = 0
+    process_list = [psutil.Process(os.getpid())]
+    try:
+        process_list.extend(process_list[0].children(recursive=True))
+    except psutil.Error:
+        pass
+    for process in process_list:
+        try:
+            total += process.memory_info().rss
+        except psutil.Error:
+            continue
+    return total
+
+
+def _memory_status_text() -> str:
+    """Return current system and workflow memory use for heartbeat logs."""
+    virtual_memory = psutil.virtual_memory()
+    return (
+        "memory: "
+        f"available={_format_bytes(virtual_memory.available)}, "
+        f"used={virtual_memory.percent:.1f}%, "
+        f"workflow_rss={_format_bytes(_process_tree_rss_bytes())}"
+    )
 
 
 def _set_tiled_geotiff_creation_options(raster_meta: dict) -> None:
@@ -328,6 +381,8 @@ def process_config(config_path: Path) -> Dict[str, Any]:
                 - 'aoi_vector_pattern' (list[str])
                 - 'analyze_full_raster_extent' (bool)
                 - 'debug_drain_index' (int | None)
+                - 'taskgraph_workers' (int | None)
+                - 'gdal_cachemax_mb' (int)
             - 'masks' (list[dict]): Each item has 'id' (str), 'type' (str),
               and 'params' (dict).
             - 'combine' (list[dict]): As provided in the YAML 'combine'
@@ -398,6 +453,33 @@ def process_config(config_path: Path) -> Dict[str, Any]:
                 "`inputs.debug_drain_index` must be a non-negative integer, "
                 f"got {debug_drain_index}"
             )
+
+    taskgraph_workers = inputs.get("taskgraph_workers", None)
+    if taskgraph_workers is not None:
+        if isinstance(taskgraph_workers, bool) or not isinstance(
+            taskgraph_workers, int
+        ):
+            raise ValueError(
+                "`inputs.taskgraph_workers` must be a positive integer, "
+                f"got {taskgraph_workers!r}"
+            )
+        if taskgraph_workers < 1:
+            raise ValueError(
+                "`inputs.taskgraph_workers` must be a positive integer, "
+                f"got {taskgraph_workers}"
+            )
+
+    gdal_cachemax_mb = inputs.get("gdal_cachemax_mb", DEFAULT_GDAL_CACHEMAX_MB)
+    if isinstance(gdal_cachemax_mb, bool) or not isinstance(gdal_cachemax_mb, int):
+        raise ValueError(
+            "`inputs.gdal_cachemax_mb` must be a positive integer, "
+            f"got {gdal_cachemax_mb!r}"
+        )
+    if gdal_cachemax_mb < 1:
+        raise ValueError(
+            "`inputs.gdal_cachemax_mb` must be a positive integer, "
+            f"got {gdal_cachemax_mb}"
+        )
 
     wgs84_pixel_size = inputs.get("wgs84_pixel_size", None)
     travel_time_pixel_size_m = inputs.get("travel_time_pixel_size_m", None)
@@ -535,6 +617,8 @@ def process_config(config_path: Path) -> Dict[str, Any]:
             "aoi_vector_pattern": aoi_vector_pattern,
             "analyze_full_raster_extent": analyze_full_raster_extent,
             "debug_drain_index": debug_drain_index,
+            "taskgraph_workers": taskgraph_workers,
+            "gdal_cachemax_mb": gdal_cachemax_mb,
             "wgs84_pixel_size": float(wgs84_pixel_size),
             "travel_time_pixel_size_m": float(travel_time_pixel_size_m),
             "buffer_size_m": float(buffer_size_m),
@@ -1418,6 +1502,7 @@ def calculate_travel_time_coverage(
     Returns:
         Path: ``target_coverage_raster_path``.
     """
+    configure_gdal_cache()
     logger = logging.getLogger(__name__)
     max_time_mins = max_hours * 60
     working_dir = Path(working_dir)
@@ -1642,6 +1727,7 @@ def calculate_downstream_coverage_from_conditional_raster(
     Returns:
         Path: ``target_coverage_raster_path``.
     """
+    configure_gdal_cache()
     logger = logging.getLogger(__name__)
     logger.debug(f"max downstream distance: {max_downstream_distance_m}")
     condition_raster_path = working_dir / f"mask_{condition_id}_{base_raster_path.name}"
@@ -1758,6 +1844,7 @@ def calculate_downstream_coverage_from_conditional_raster(
 
 
 def calc_flow_dir(dem_path, working_dir, target_flow_dir_raster_path):
+    configure_gdal_cache()
     pit_filled_raster_path = working_dir / f"pit_filled_{Path(dem_path).name}"
     routing.fill_pits(
         (dem_path, 1),
@@ -2185,18 +2272,36 @@ def calculate_taskgraph_worker_count(config: dict, work_unit_count: int) -> int:
             units that will be processed.
 
     Returns:
-        Worker count bounded by the physical CPU count. The value is at least
-        one and adds two extra slots when travel-time work can run alongside
-        AOI downstream preparation.
+        Worker count bounded by the physical CPU count. Conditional routing
+        workflows default to a conservative worker count because DEM routing
+        and raster warping are memory-heavy.
     """
     physical_cpu_count = psutil.cpu_count(logical=False) or psutil.cpu_count() or 1
+    configured_workers = config.get("inputs", {}).get("taskgraph_workers")
+    if configured_workers is not None:
+        return min(int(configured_workers), physical_cpu_count)
+
     has_travel_time_mask = any(
         mask.get("type") == "travel_time_population" for mask in config.get("masks", [])
     )
+    has_conditional_mask = any(
+        mask.get("type") == "conditional_raster" for mask in config.get("masks", [])
+    )
 
-    desired_worker_count = max(1, work_unit_count)
+    if has_conditional_mask:
+        desired_worker_count = min(
+            DEFAULT_CONDITIONAL_TASKGRAPH_WORKERS,
+            max(1, work_unit_count),
+        )
+    elif has_travel_time_mask:
+        desired_worker_count = min(
+            DEFAULT_TRAVEL_TIME_TASKGRAPH_WORKERS,
+            max(1, work_unit_count),
+        )
+    else:
+        desired_worker_count = max(1, work_unit_count)
     if has_travel_time_mask:
-        desired_worker_count += 2
+        desired_worker_count = max(2, desired_worker_count)
     return min(desired_worker_count, physical_cpu_count)
 
 
@@ -2217,6 +2322,8 @@ def main() -> None:
     output_dir = Path(config["output_dir"])
     output_dir.mkdir(parents=True, exist_ok=True)
     logger = setup_logger(config["logging"]["level"], config["logging"]["to_file"])
+    gdal_cachemax_mb = configure_gdal_cache(config["inputs"]["gdal_cachemax_mb"])
+    logger.info("using GDAL cache max of %d MiB per process", gdal_cachemax_mb)
 
     validate_paths(config)
     logger.info(f"{args.config} read successfully")
@@ -2285,6 +2392,7 @@ def main() -> None:
     union_population_id = "union_population"
     population_result_ids.add(union_population_id)
     population_results = collections.defaultdict(dict)
+    task_progress_paths = []
     for aoi_key, aoi_info in aoi_work_items.items():
         aoi_vector_path = aoi_info["aoi_vector_path"]
         working_dir = aoi_info["working_dir"]
@@ -2358,6 +2466,7 @@ def main() -> None:
                     partition_coverage_raster_path = (
                         partition_context["working_dir"] / f"{section_id}_coverage.tif"
                     )
+                    task_progress_paths.append(partition_coverage_raster_path)
                     partition_coverage_id_raster_list.append(
                         (partition_id, partition_coverage_raster_path)
                     )
@@ -2400,6 +2509,7 @@ def main() -> None:
                     partition_coverage_raster_path = (
                         partition_context["working_dir"] / f"{section_id}_coverage.tif"
                     )
+                    task_progress_paths.append(partition_coverage_raster_path)
                     partition_coverage_id_raster_list.append(
                         (partition_id, partition_coverage_raster_path)
                     )
@@ -2443,6 +2553,7 @@ def main() -> None:
                 task_name=f"stitch coverage for {aoi_key} {section_id}",
             )
             coverage_raster_tasks[section_id] = section_coverage_task
+            task_progress_paths.append(target_coverage_raster_path)
             coverage_id_raster_list.append((section_id, target_coverage_raster_path))
 
             target_population_raster_path = (
@@ -2461,8 +2572,10 @@ def main() -> None:
                 task_name=f"mask population for {aoi_key} {section_id}",
             )
             population_results[aoi_key][f"{section_id}_population"] = population_task
+            task_progress_paths.append(target_population_raster_path)
 
         target_union_coverage_raster_path = output_dir / f"{aoi_key}_union_coverage.tif"
+        task_progress_paths.append(target_union_coverage_raster_path)
         union_coverage_task = task_graph.add_task(
             func=stitch_coverage_masks,
             args=(
@@ -2492,9 +2605,25 @@ def main() -> None:
             task_name=f"mask population for {aoi_key} union",
         )
         population_results[aoi_key][union_population_id] = union_population_task
+        task_progress_paths.append(target_union_population_raster_path)
 
     task_graph.close()
-    task_graph.join()
+    def _task_progress_message() -> str:
+        complete_count = 0
+        for target_path in task_progress_paths:
+            try:
+                if Path(target_path).exists() and Path(target_path).stat().st_size > 0:
+                    complete_count += 1
+            except OSError:
+                pass
+        return (
+            "workflow tasks running: "
+            f"{complete_count}/{len(task_progress_paths)} target rasters present; "
+            f"{_memory_status_text()}"
+        )
+
+    with _log_heartbeat(logger, _task_progress_message):
+        task_graph.join()
     rows = []
     for aoi_key, results in population_results.items():
         row = {"aoi": aoi_key}

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -1370,7 +1370,10 @@ def mask_raster_to_vector(raster_path: str | Path, vector_path: str | Path) -> N
         if not geometries:
             raise ValueError(f"No valid geometries found in {vector_path}.")
 
-        outside_value = raster.nodata if raster.nodata is not None else 0
+        outside_value = raster.nodata
+        if outside_value is None:
+            outside_value = _default_nodata_for_dtype(raster.dtypes[0])
+            raster.nodata = outside_value
         for _, window in raster.block_windows(1):
             block = raster.read(1, window=window)
             inside_mask = rasterio.features.geometry_mask(
@@ -1381,6 +1384,19 @@ def mask_raster_to_vector(raster_path: str | Path, vector_path: str | Path) -> N
             )
             block[~inside_mask] = outside_value
             raster.write(block, 1, window=window)
+
+
+def _default_nodata_for_dtype(dtype) -> int | float:
+    """Return a dtype-safe nodata value for rasters that do not define one."""
+    dtype = np.dtype(dtype)
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        if np.issubdtype(dtype, np.signedinteger):
+            return int(info.min)
+        return int(info.max)
+    if np.issubdtype(dtype, np.floating):
+        return float(-np.finfo(dtype).max)
+    raise ValueError(f"No default nodata value is defined for dtype {dtype}")
 
 
 def eck4_limits(r=6371000):

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -129,6 +129,26 @@ def _memory_status_text() -> str:
     )
 
 
+@contextlib.contextmanager
+def _log_memory_scope(logger: logging.Logger, label: str):
+    """Log process-tree memory before and after a diagnostic scope."""
+    start_time = time.monotonic()
+    start_rss = _process_tree_rss_bytes()
+    logger.info("%s started; %s", label, _memory_status_text())
+    try:
+        yield
+    finally:
+        end_rss = _process_tree_rss_bytes()
+        elapsed_seconds = time.monotonic() - start_time
+        logger.info(
+            "%s finished in %.1fs; rss_delta=%s; %s",
+            label,
+            elapsed_seconds,
+            _format_bytes(end_rss - start_rss),
+            _memory_status_text(),
+        )
+
+
 def _set_tiled_geotiff_creation_options(raster_meta: dict) -> None:
     """Set Rasterio creation options for block-aligned GeoTIFF writes."""
     raster_meta.update(
@@ -1603,7 +1623,7 @@ def calculate_windowed_travel_reach(
                     desc=progress_label or f"travel windows {target_coverage_raster_path.stem}",
                     unit="window",
                 )
-                for core_window in progress:
+                for window_index, core_window in enumerate(progress, start=1):
                     core_mask = source_mask.read(1, window=core_window)
                     if not np.any(core_mask == 1):
                         skipped_windows += 1
@@ -1644,15 +1664,24 @@ def calculate_windowed_travel_reach(
                     ).astype(np.int8)
 
                     n_rows, n_cols = friction_array.shape
-                    reach_array = shortest_distances.find_mask_reach(
-                        friction_array,
-                        source_array,
-                        cell_length_m,
-                        n_cols,
-                        n_rows,
-                        max_time_mins,
-                        progress_interval_seconds=0,
+                    reach_label = (
+                        "find_mask_reach "
+                        f"{target_coverage_raster_path.stem} "
+                        f"window={window_index}/{total_windows} "
+                        f"core={int(core_window.width)}x{int(core_window.height)} "
+                        f"buffered={n_cols}x{n_rows} "
+                        f"estimated_arrays={_format_bytes(estimated_bytes)}"
                     )
+                    with _log_memory_scope(logger, reach_label):
+                        reach_array = shortest_distances.find_mask_reach(
+                            friction_array,
+                            source_array,
+                            cell_length_m,
+                            n_cols,
+                            n_rows,
+                            max_time_mins,
+                            progress_interval_seconds=0,
+                        )
 
                     existing_array = target.read(1, window=buffered_window)
                     np.maximum(existing_array, reach_array, out=existing_array)
@@ -1700,6 +1729,10 @@ def calculate_travel_time_coverage(
     """
     configure_gdal_cache()
     logger = logging.getLogger(__name__)
+    worker_label = f"travel-time coverage worker {Path(aoi_vector_path).stem}"
+    worker_start_time = time.monotonic()
+    worker_start_rss = _process_tree_rss_bytes()
+    logger.info("%s started; %s", worker_label, _memory_status_text())
     max_time_mins = max_hours * 60
     working_dir = Path(working_dir)
     working_dir.mkdir(parents=True, exist_ok=True)
@@ -1780,7 +1813,7 @@ def calculate_travel_time_coverage(
         wgs84_bounds=aoi_wgs84_bounds,
     )
 
-    return calculate_windowed_travel_reach(
+    result_path = calculate_windowed_travel_reach(
         target_friction_clipped_raster_path,
         target_aoi_raster_path,
         target_coverage_raster_path,
@@ -1788,6 +1821,14 @@ def calculate_travel_time_coverage(
         buffer_pixels,
         progress_label=f"travel windows {Path(aoi_vector_path).stem}",
     )
+    logger.info(
+        "%s finished in %.1fs; rss_delta=%s; %s",
+        worker_label,
+        time.monotonic() - worker_start_time,
+        _format_bytes(_process_tree_rss_bytes() - worker_start_rss),
+        _memory_status_text(),
+    )
+    return result_path
 
 
 def create_distance_transform(
@@ -1929,6 +1970,10 @@ def calculate_downstream_coverage_from_conditional_raster(
     """
     configure_gdal_cache()
     logger = logging.getLogger(__name__)
+    worker_label = f"downstream coverage worker {condition_id} {Path(aoi_vector_path).stem}"
+    worker_start_time = time.monotonic()
+    worker_start_rss = _process_tree_rss_bytes()
+    logger.info("%s started; %s", worker_label, _memory_status_text())
     logger.debug(f"max downstream distance: {max_downstream_distance_m}")
     condition_raster_path = working_dir / f"mask_{condition_id}_{base_raster_path.name}"
 
@@ -2040,11 +2085,23 @@ def calculate_downstream_coverage_from_conditional_raster(
         calc_raster_stats=False,
         raster_driver_creation_tuple=GTIFF_CREATION_TUPLE,
     )
+    logger.info(
+        "%s finished in %.1fs; rss_delta=%s; %s",
+        worker_label,
+        time.monotonic() - worker_start_time,
+        _format_bytes(_process_tree_rss_bytes() - worker_start_rss),
+        _memory_status_text(),
+    )
     return target_coverage_raster_path
 
 
 def calc_flow_dir(dem_path, working_dir, target_flow_dir_raster_path):
     configure_gdal_cache()
+    logger = logging.getLogger(__name__)
+    worker_label = f"flow direction worker {Path(target_flow_dir_raster_path).stem}"
+    worker_start_time = time.monotonic()
+    worker_start_rss = _process_tree_rss_bytes()
+    logger.info("%s started; %s", worker_label, _memory_status_text())
     pit_filled_raster_path = working_dir / f"pit_filled_{Path(dem_path).name}"
     routing.fill_pits(
         (dem_path, 1),
@@ -2057,6 +2114,13 @@ def calc_flow_dir(dem_path, working_dir, target_flow_dir_raster_path):
         str(target_flow_dir_raster_path),
         working_dir=str(working_dir),
         raster_driver_creation_tuple=GTIFF_CREATION_TUPLE,
+    )
+    logger.info(
+        "%s finished in %.1fs; rss_delta=%s; %s",
+        worker_label,
+        time.monotonic() - worker_start_time,
+        _format_bytes(_process_tree_rss_bytes() - worker_start_rss),
+        _memory_status_text(),
     )
 
 

--- a/workflow_runner.py
+++ b/workflow_runner.py
@@ -2148,6 +2148,45 @@ def _raster_bounds_in_crs(raster: rasterio.DatasetReader, target_crs) -> tuple:
     )
 
 
+def _split_wgs84_antimeridian_bounds(bounds: tuple) -> list[tuple]:
+    """Clip WGS84 bounds into non-wrapping longitude intervals.
+
+    Raster bounds transformed to WGS84 can wrap across the antimeridian, for
+    example ``(167, bottom, -179, top)``. Rasterio window calculations expect
+    left <= right, so split wrapped bounds into east and west pieces clipped to
+    the valid longitude range.
+    """
+    left, bottom, right, top = bounds
+    left = max(-180.0, min(180.0, left))
+    right = max(-180.0, min(180.0, right))
+    bottom = max(-90.0, min(90.0, bottom))
+    top = max(-90.0, min(90.0, top))
+
+    if bottom >= top:
+        return []
+    if left <= right:
+        if left == right:
+            return []
+        return [(left, bottom, right, top)]
+
+    split_bounds = []
+    if left < 180.0:
+        split_bounds.append((left, bottom, 180.0, top))
+    if right > -180.0:
+        split_bounds.append((-180.0, bottom, right, top))
+    return split_bounds
+
+
+def _floor_to_grid(value: float, pixel_size: float) -> float:
+    """Floor ``value`` to a grid while tolerating tiny floating-point drift."""
+    return math.floor(value / pixel_size + 1e-9) * pixel_size
+
+
+def _ceil_to_grid(value: float, pixel_size: float) -> float:
+    """Ceil ``value`` to a grid while tolerating tiny floating-point drift."""
+    return math.ceil(value / pixel_size - 1e-9) * pixel_size
+
+
 def _combined_raster_profile(
     raster_path_list: list[str],
     wgs84_pixel_size: float,
@@ -2182,19 +2221,22 @@ def _combined_raster_profile(
 
     for raster_path in raster_path_list:
         with rasterio.open(raster_path) as raster:
-            left, bottom, right, top = _raster_bounds_in_crs(raster, target_crs)
-        minx = min(minx, left)
-        miny = min(miny, bottom)
-        maxx = max(maxx, right)
-        maxy = max(maxy, top)
+            raster_bounds = _raster_bounds_in_crs(raster, target_crs)
+        for left, bottom, right, top in _split_wgs84_antimeridian_bounds(
+            raster_bounds
+        ):
+            minx = min(minx, left)
+            miny = min(miny, bottom)
+            maxx = max(maxx, right)
+            maxy = max(maxy, top)
 
     if not all(math.isfinite(value) for value in [minx, miny, maxx, maxy]):
         raise ValueError("No valid raster bounds were found for population combine.")
 
-    minx = math.floor(minx / pixel_size) * pixel_size
-    miny = math.floor(miny / pixel_size) * pixel_size
-    maxx = math.ceil(maxx / pixel_size) * pixel_size
-    maxy = math.ceil(maxy / pixel_size) * pixel_size
+    minx = _floor_to_grid(minx, pixel_size)
+    miny = _floor_to_grid(miny, pixel_size)
+    maxx = _ceil_to_grid(maxx, pixel_size)
+    maxy = _ceil_to_grid(maxy, pixel_size)
 
     width = int(math.ceil((maxx - minx) / pixel_size))
     height = int(math.ceil((maxy - miny) / pixel_size))
@@ -2403,12 +2445,10 @@ def stitch_coverage_masks(
                     source_count = np.float64(0)
                     with rasterio.open(source_path) as source:
                         source_bounds = _raster_bounds_in_crs(source, target_crs)
-                        target_window = _integer_window(
-                            from_bounds(*source_bounds, transform=target_transform),
-                            target.width,
-                            target.height,
+                        source_bounds_list = _split_wgs84_antimeridian_bounds(
+                            source_bounds
                         )
-                        if target_window.width == 0 or target_window.height == 0:
+                        if not source_bounds_list:
                             coverage_counts_by_id[coverage_id] = source_count
                             continue
 
@@ -2424,18 +2464,33 @@ def stitch_coverage_masks(
                             vrt_kwargs["src_nodata"] = source.nodata
 
                         with WarpedVRT(source, **vrt_kwargs) as source_vrt:
-                            for window in _iter_block_windows(target_window):
-                                incoming = source_vrt.read(1, window=window)
-                                incoming = (incoming > 0).astype(np.uint8)
-                                stitch_state["pixels"] += int(
-                                    window.width * window.height
+                            for bounds_part in source_bounds_list:
+                                target_window = _integer_window(
+                                    from_bounds(
+                                        *bounds_part,
+                                        transform=target_transform,
+                                    ),
+                                    target.width,
+                                    target.height,
                                 )
-                                source_count += np.sum(incoming, dtype=np.float64)
-                                if not np.any(incoming):
+                                if (
+                                    target_window.width == 0
+                                    or target_window.height == 0
+                                ):
                                     continue
-                                existing = target.read(1, window=window)
-                                np.maximum(existing, incoming, out=existing)
-                                target.write(existing, 1, window=window)
+
+                                for window in _iter_block_windows(target_window):
+                                    incoming = source_vrt.read(1, window=window)
+                                    incoming = (incoming > 0).astype(np.uint8)
+                                    stitch_state["pixels"] += int(
+                                        window.width * window.height
+                                    )
+                                    source_count += np.sum(incoming, dtype=np.float64)
+                                    if not np.any(incoming):
+                                        continue
+                                    existing = target.read(1, window=window)
+                                    np.maximum(existing, incoming, out=existing)
+                                    target.write(existing, 1, window=window)
 
                     coverage_counts_by_id[coverage_id] = source_count
                     stitch_state["index"] = raster_index


### PR DESCRIPTION
## Summary
- Default conditional/routing workflows to a conservative TaskGraph worker count of 2, while keeping an explicit `inputs.taskgraph_workers` override for tuning.
- Add `inputs.gdal_cachemax_mb` with a default 128 MiB GDAL cache cap per process, applied in the main process and worker-heavy raster functions.
- Add periodic TaskGraph heartbeat logging that reports completed target rasters plus system available memory, memory percent used, and workflow process-tree RSS.
- Guard travel-time reach priority queues and skip non-finite friction values so NaNs cannot create runaway queue growth.
- Clip antimeridian-crossing WGS84 coverage bounds into east/west pieces before stitching, avoiding wrapped bounds errors.
- Mask clipped DEM pixels outside drain polygons to a dtype-safe nodata value when the DEM has no nodata metadata, so routing does not operate across rectangular outside-drain areas.
- Add unit coverage for the new worker-count defaults, travel-reach diagnostics, non-finite friction handling, antimeridian stitching bounds, and clipped DEM nodata masking.

Closes #89
Closes #91
Closes #92

## Testing
- `python -m py_compile workflow_runner.py tests\test_workflow_runner.py`
- `mamba run -n zonal-stats-toolkit python setup.py build_ext --inplace`
- `mamba run -n zonal-stats-toolkit python -m unittest tests.test_workflow_runner`
- `mamba run -n zonal-stats-toolkit python -m unittest tests.test_population_combine_nodata`
- Local scan of 5,421 saved `within_travel_time_coverage.tif` drain rasters confirmed 21 antimeridian-wrapped rasters and 0 remaining `from_bounds` window errors after splitting bounds.

## Notes
- This does not fully serialize workflow stages. Instead, it reduces the default fanout for memory-heavy routing workflows and adds enough heartbeat telemetry to tell whether memory pressure is rising during a long run.
- Worker-process tqdm bars can still interleave when multiple workers write progress at once, but the lower default worker count and the main-process heartbeat should make failures easier to localize.