### PR TITLE
Add July hotspot beneficiary configs

### DIFF
--- a/configs/jeronimo_2026_07_access_overlap_travel_time_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_access_overlap_travel_time_beneficiaries.yaml
@@ -1,0 +1,37 @@
+# July 2026 access/coastal/pollination overlap hotspots, travel-time beneficiaries only.
+# Source raster values 1-3 are access/coastal/pollination overlap hotspots; 255 is nodata.
+# python workflow_runner.py configs/jeronimo_2026_07_access_overlap_travel_time_beneficiaries.yaml
+run_name: jeronimo_2026_07_access_overlap_travel_time_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_access_overlap_travel_time_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_access_overlap_travel_time_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: within_travel_time
+      type: travel_time_population
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/count_access_pct.tif"
+        expression: 'value > 0'
+        max_hours: 1.0
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log

--- a/configs/jeronimo_2026_07_combined_cross_category_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_combined_cross_category_beneficiaries.yaml
@@ -1,0 +1,43 @@
+# July 2026 combined cross-category hotspots.
+# Source raster value 1 means at least one water and at least one access/coastal/pollination service; 255 is nodata.
+# python workflow_runner.py configs/jeronimo_2026_07_combined_cross_category_beneficiaries.yaml
+run_name: jeronimo_2026_07_combined_cross_category_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_combined_cross_category_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_combined_cross_category_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: within_travel_time
+      type: travel_time_population
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/combined_cross_pct.tif"
+        expression: 'value == 1'
+        max_hours: 1.0
+    - id: downstream_50k
+      type: conditional_raster
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/combined_cross_pct.tif"
+        expression: 'value == 1'
+        max_downstream_distance_m: 50000
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log

--- a/configs/jeronimo_2026_07_hotspot_count_1plus_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_hotspot_count_1plus_beneficiaries.yaml
@@ -1,0 +1,42 @@
+# July 2026 retained-service hotspot count, 1+ services.
+# python workflow_runner.py configs/jeronimo_2026_07_hotspot_count_1plus_beneficiaries.yaml
+run_name: jeronimo_2026_07_hotspot_count_1plus_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_1plus_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_1plus_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: within_travel_time
+      type: travel_time_population
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 0'
+        max_hours: 1.0
+    - id: downstream_50k
+      type: conditional_raster
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 0'
+        max_downstream_distance_m: 50000
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log

--- a/configs/jeronimo_2026_07_hotspot_count_2plus_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_hotspot_count_2plus_beneficiaries.yaml
@@ -1,0 +1,42 @@
+# July 2026 retained-service hotspot count, 2+ services.
+# python workflow_runner.py configs/jeronimo_2026_07_hotspot_count_2plus_beneficiaries.yaml
+run_name: jeronimo_2026_07_hotspot_count_2plus_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_2plus_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_2plus_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: within_travel_time
+      type: travel_time_population
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 1'
+        max_hours: 1.0
+    - id: downstream_50k
+      type: conditional_raster
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 1'
+        max_downstream_distance_m: 50000
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log

--- a/configs/jeronimo_2026_07_hotspot_count_3plus_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_hotspot_count_3plus_beneficiaries.yaml
@@ -1,0 +1,42 @@
+# July 2026 retained-service hotspot count, 3+ services.
+# python workflow_runner.py configs/jeronimo_2026_07_hotspot_count_3plus_beneficiaries.yaml
+run_name: jeronimo_2026_07_hotspot_count_3plus_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_3plus_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_3plus_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: within_travel_time
+      type: travel_time_population
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 2'
+        max_hours: 1.0
+    - id: downstream_50k
+      type: conditional_raster
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 2'
+        max_downstream_distance_m: 50000
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log

--- a/configs/jeronimo_2026_07_hotspot_count_4plus_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_hotspot_count_4plus_beneficiaries.yaml
@@ -1,0 +1,42 @@
+# July 2026 retained-service hotspot count, 4+ services.
+# python workflow_runner.py configs/jeronimo_2026_07_hotspot_count_4plus_beneficiaries.yaml
+run_name: jeronimo_2026_07_hotspot_count_4plus_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_4plus_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_4plus_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: within_travel_time
+      type: travel_time_population
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 3'
+        max_hours: 1.0
+    - id: downstream_50k
+      type: conditional_raster
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 3'
+        max_downstream_distance_m: 50000
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log

--- a/configs/jeronimo_2026_07_hotspot_count_5plus_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_hotspot_count_5plus_beneficiaries.yaml
@@ -1,0 +1,42 @@
+# July 2026 retained-service hotspot count, 5+ services.
+# python workflow_runner.py configs/jeronimo_2026_07_hotspot_count_5plus_beneficiaries.yaml
+run_name: jeronimo_2026_07_hotspot_count_5plus_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_5plus_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_hotspot_count_5plus_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: within_travel_time
+      type: travel_time_population
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 4'
+        max_hours: 1.0
+    - id: downstream_50k
+      type: conditional_raster
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/hotspot_count_pct_2026_07_29_18_49_00.tif"
+        expression: 'value > 4'
+        max_downstream_distance_m: 50000
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log

--- a/configs/jeronimo_2026_07_water_overlap_downstream_beneficiaries.yaml
+++ b/configs/jeronimo_2026_07_water_overlap_downstream_beneficiaries.yaml
@@ -1,0 +1,37 @@
+# July 2026 water overlap hotspots, downstream beneficiaries only.
+# Source raster values 1-2 are water overlap hotspots; 255 is nodata.
+# python workflow_runner.py configs/jeronimo_2026_07_water_overlap_downstream_beneficiaries.yaml
+run_name: jeronimo_2026_07_water_overlap_downstream_beneficiaries
+work_dir: ./output_jeronimo_2026_07_29_18_49_00_water_overlap_downstream_beneficiaries/workdir
+output_dir: ./output_jeronimo_2026_07_29_18_49_00_water_overlap_downstream_beneficiaries
+
+inputs:
+  # leave pixel sizes alone unless you know what you're doing
+  wgs84_pixel_size: 0.008333333333333
+  travel_time_pixel_size_m: 900
+  buffer_size_m: 5000
+  population_raster_path: "./data/pop_rasters/landscan-global-2023.tif"
+  traveltime_raster_path: "./data/travel_time/friction_surface_2019_compressed_md5_1be7dd230178a5d395529be7a5e3fb0a.tif"
+  dem_raster_path: "./data/dem_precondition/astgtm_compressed.tif"
+  subwatershed_vector_path: "./data/dem_precondition/merged_lev06.shp"
+  analyze_full_raster_extent: true
+  taskgraph_workers: 12
+  gdal_cachemax_mb: 128
+  #debug_drain_index: 170
+  aoi_vector_pattern:
+  #  - "./wwf_aois/*.gpkg"
+
+sections:
+  - masks:
+    - id: downstream_50k
+      type: conditional_raster
+      params:
+        condition_raster_path: "D:/Users/richp/Downloads/hotspots_rasters-20260729T024121Z-1-001/hotspots_rasters/count_water_pct.tif"
+        expression: 'value > 0'
+        max_downstream_distance_m: 50000
+  - combine:
+    - logic: OR
+
+logging:
+  level: INFO
+  to_file: output.log


### PR DESCRIPTION
## Summary

- Adds standalone July 2026 beneficiary configs for Jeronimo's updated hotspot rasters.
- Adds 1+, 2+, 3+, 4+, and 5+ retained-service hotspot count configs using `hotspot_count_pct_2026_07_29_18_49_00.tif`.
- Adds water-overlap downstream-only, access/coastal/pollination travel-time-only, and combined cross-category beneficiary configs.
- Uses descriptive run names and output directories with the `2026_07_29_18_49_00` raster timestamp so Becky can identify outputs directly.

Closes #95.

## Testing

- Parsed each new config with `workflow_runner.process_config` and checked configured input paths with `workflow_runner.validate_paths` using `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe`.
- `git diff --cached --check`

## Notes

The Slack-derived request mapped cleanly to seven configs, so this includes a `5plus` hotspot-count config as the eighth because the new retained-service count raster ranges from 1-5.